### PR TITLE
Use env vars for Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+# Copy this file to `.env` and fill in your Supabase credentials
+SUPABASE_URL=""
+SUPABASE_KEY=""

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,10 +2,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://frqansjbzjdfxvilfcig.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZycWFuc2piempkZnh2aWxmY2lnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgzOTI5MTIsImV4cCI6MjA2Mzk2ODkxMn0.hUvPgFTw7J-niZOiidHbFnZ_zuudTtxudoVfHnY85Tg";
+const SUPABASE_URL = import.meta.env.SUPABASE_URL;
+const SUPABASE_KEY = import.meta.env.SUPABASE_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_KEY);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  envPrefix: ["VITE_", "SUPABASE_"] as const,
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- load Supabase credentials from `import.meta.env`
- expose `SUPABASE_` variables to the client in Vite
- add `.env.example` with required variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843538a76408330aee471ce79b05347