### PR TITLE
Add overdue period filter

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -62,6 +62,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">Todos os períodos</SelectItem>
+            <SelectItem value="overdue">Atrasados</SelectItem>
             <SelectItem value="1month">1 mês</SelectItem>
             <SelectItem value="3months">3 meses</SelectItem>
             <SelectItem value="6months">6 meses</SelectItem>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -50,26 +50,49 @@ const Index = () => {
   const filteredPatients = patients.filter(patient => {
     if (statusFilter !== 'all' && patient.status !== statusFilter) return false;
     if (paymentFilter !== 'all' && patient.paymentType !== paymentFilter) return false;
-    if (searchTerm && !patient.name.toLowerCase().includes(searchTerm.toLowerCase()) && 
-        !patient.phone.includes(searchTerm)) return false;
-    
-    if (overdueFilter) {
-      return isAfter(today, startOfDay(patient.nextContactDate));
+    if (
+      searchTerm &&
+      !patient.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
+      !patient.phone.includes(searchTerm)
+    )
+      return false;
+
+    const nextContactDate = startOfDay(patient.nextContactDate);
+    const isPatientOverdue = isAfter(today, nextContactDate);
+
+    // Filtro "Atrasados" no seletor de período
+    if (contactPeriodFilter === 'overdue') {
+      return isPatientOverdue;
     }
-    
+
+    // Botão "Apenas atrasados" só funciona quando o período é "Todos"
+    if (overdueFilter && contactPeriodFilter === 'all') {
+      return isPatientOverdue;
+    }
+
+    // Nas opções de período (1m, 3m, 6m, 1a) ignorar pacientes atrasados
     if (contactPeriodFilter !== 'all') {
-      const nextContactDate = startOfDay(patient.nextContactDate);
-      const daysDiff = Math.ceil((nextContactDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
-      
+      if (isPatientOverdue) return false;
+
+      const daysDiff = Math.ceil(
+        (nextContactDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+      );
+
       switch (contactPeriodFilter) {
-        case '1month': return daysDiff <= 30;
-        case '3months': return daysDiff <= 90;
-        case '6months': return daysDiff <= 180;
-        case '1year': return daysDiff <= 365;
-        default: return true;
+        case '1month':
+          return daysDiff <= 30;
+        case '3months':
+          return daysDiff <= 90;
+        case '6months':
+          return daysDiff <= 180;
+        case '1year':
+          return daysDiff <= 365;
+        default:
+          return true;
       }
     }
-    
+
+    // "Todos os períodos" sem filtro de atraso exibe todos
     return true;
   });
 

--- a/src/types/patient.ts
+++ b/src/types/patient.ts
@@ -36,4 +36,10 @@ export interface ContactRecord {
   successful: boolean;
 }
 
-export type ContactPeriod = '1month' | '3months' | '6months' | '1year' | 'custom';
+export type ContactPeriod =
+  | 'overdue'
+  | '1month'
+  | '3months'
+  | '6months'
+  | '1year'
+  | 'custom';


### PR DESCRIPTION
## Summary
- add 'overdue' option to `ContactPeriod`
- show 'Atrasados' in period filter dropdown
- display overdue patients only when period filter is `Atrasados` or `Todos períodos`

## Testing
- `npm run lint` *(fails: several eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861bae5d2748330b0582cc0c5e1589d