### PR TITLE
Add cancel option to import screen

### DIFF
--- a/src/components/ExcelImport.tsx
+++ b/src/components/ExcelImport.tsx
@@ -277,6 +277,9 @@ export const ExcelImport: React.FC<ExcelImportProps> = ({ onImport, onCancel }) 
                   </p>
                 </div>
               </div>
+              <div className="flex justify-end">
+                <Button variant="outline" onClick={onCancel}>Cancelar</Button>
+              </div>
             </div>
           ) : (
             <div className="space-y-4">


### PR DESCRIPTION
## Summary
- add a cancel button to Excel import screen for when no file has been uploaded

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68684fa5bae083308356cc494b5b6a84