### PR TITLE
Fix active patients card filter behavior

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -169,6 +169,7 @@ const Index = () => {
   };
 
   const handleActivePatientsClick = () => {
+    resetFilters();
     setStatusFilter('active');
 
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- clear all filters when clicking the Active Patients card

## Testing
- `npm run lint` *(fails: several lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687437fbcc308330baa2ad21f1dcb9e0