### PR TITLE
fix appointment patient dropdown

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -248,7 +248,11 @@ export function AppointmentModal({
                     <User className="w-4 h-4" />
                     Paciente
                   </FormLabel>
-                  <Popover open={patientSearchOpen} onOpenChange={setPatientSearchOpen}>
+                  <Popover
+                    open={patientSearchOpen}
+                    onOpenChange={setPatientSearchOpen}
+                    modal={false}
+                  >
                     <PopoverTrigger asChild>
                       <FormControl>
                         <Button
@@ -263,7 +267,7 @@ export function AppointmentModal({
                         </Button>
                       </FormControl>
                     </PopoverTrigger>
-                    <PopoverContent className="w-full p-0">
+                    <PopoverContent className="w-full p-0 z-[60]">
                       <Command>
                         <CommandInput placeholder="Buscar paciente..." />
                         <CommandList>


### PR DESCRIPTION
## Summary
- ensure patient dropdown options can be selected in appointment modal by raising z-index and disabling modal behavior on popover

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fd770edd08330963f5c12fb4f9c6d