### PR TITLE
fix: allow patient selection in appointment modal

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -256,6 +256,7 @@ export function AppointmentModal({
                     <PopoverTrigger asChild>
                       <FormControl>
                         <Button
+                          type="button"
                           variant="outline"
                           role="combobox"
                           className="w-full justify-between"


### PR DESCRIPTION
## Summary
- prevent form submission when opening patient picker by setting button type to `button`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_688fdb203b9c8330b0f2d7ae20445b32