### PR TITLE
Fix patient selection field retaining name

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -250,14 +250,10 @@ export function AppointmentModal({
                       <FormControl>
                         <Input
                           placeholder="Digite para buscar..."
-                          value={
-                            field.value
-                              ? patients.find((p) => p.id === field.value)?.name || ''
-                              : patientSearch
-                          }
+                          value={patientSearch}
                           onChange={(e) => {
                             setPatientSearch(e.target.value);
-                            field.onChange('');
+                            if (field.value) field.onChange('');
                             setPatientSearchOpen(true);
                           }}
                           onFocus={() => setPatientSearchOpen(true)}


### PR DESCRIPTION
## Summary
- keep typed patient name in appointment modal after selection
- reset patient id when search text changes

## Testing
- `npm run lint` *(fails: unexpected any, prefer-const, etc.)*
- `npx eslint src/components/AppointmentModal.tsx`
- `npm test` *(fails: Missing script "test")*
- manual simulation verifying `patientSearch` and `patient_id` updates

------
https://chatgpt.com/codex/tasks/task_e_6892949b8020833098223d0331685ac8