### PR TITLE
Add nested patient form to appointment modal

### DIFF
--- a/src/hooks/useSupabasePatients.ts
+++ b/src/hooks/useSupabasePatients.ts
@@ -63,7 +63,10 @@ export const useSupabasePatients = (organizationId: string | undefined) => {
   };
 
   // Add patient to Supabase
-  const addPatient = async (patientData: PatientCreateData, userId: string) => {
+  const addPatient = async (
+    patientData: PatientCreateData,
+    userId: string
+  ): Promise<Patient | void> => {
     console.log('🚀 Starting addPatient:', { patientName: patientData.name, userId, organizationId });
     
     if (!organizationId) {
@@ -99,6 +102,7 @@ export const useSupabasePatients = (organizationId: string | undefined) => {
       });
       
       console.log('✅ Patient added successfully to state');
+      return newPatient;
     } catch (error) {
       console.error('❌ Error adding patient:', error);
       

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -7,9 +7,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useAppointments } from '@/hooks/useAppointments';
-import { useSupabasePatients } from '@/hooks/useSupabasePatients';
-import { useAuth } from '@/hooks/useAuth';
-import { useOrganization } from '@/hooks/useOrganization';
 import { AppointmentModal } from '@/components/AppointmentModal';
 import { Appointment } from '@/types/appointment';
 
@@ -20,9 +17,6 @@ export default function Appointments() {
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<{ date: Date; hour: number } | null>(null);
 
   const { appointments, locations, loading } = useAppointments();
-  const { user } = useAuth();
-  const { userProfile } = useOrganization(user);
-  const { patients } = useSupabasePatients(userProfile?.organization_id);
 
   const weekStart = startOfWeek(currentWeek, { weekStartsOn: 1 });
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
@@ -216,7 +210,6 @@ export default function Appointments() {
         onClose={() => setIsModalOpen(false)}
         appointment={selectedAppointment}
         selectedTimeSlot={selectedTimeSlot}
-        patients={patients}
         locations={locations}
       />
     </div>


### PR DESCRIPTION
## Summary
- allow patient creation inside appointment modal via nested `PatientForm`
- refresh and preselect new patient on save
- expose newly added patient from `useSupabasePatients`

## Testing
- `npm run lint` *(fails: Unexpected any errors in unrelated files)*
- `npx eslint src/components/AppointmentModal.tsx src/hooks/useSupabasePatients.ts src/pages/Appointments.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6892952aba8083308ee71c114c287768