### PR TITLE
fix: ensure patient selection always updates field

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -291,6 +291,12 @@ export function AppointmentModal({
                                     <CommandItem
                                       key={patient.id}
                                       value={`${patient.name} ${patient.phone}`}
+                                      onMouseDown={(e) => {
+                                        e.preventDefault();
+                                        field.onChange(patient.id);
+                                        setPatientSearch(patient.name);
+                                        setPatientSearchOpen(false);
+                                      }}
                                       onSelect={() => {
                                         field.onChange(patient.id);
                                         setPatientSearch(patient.name);


### PR DESCRIPTION
## Summary
- fix patient search to reliably set the selected patient

## Testing
- `npm run lint` (fails: 27 problems)
- `npx eslint src/components/AppointmentModal.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68929b2338a88330b48fad64db56cd3d