### PR TITLE
refactor: reuse patient add flow in appointments modal

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -34,8 +34,14 @@ export default function Appointments() {
     updateOrganizationSettings
   } = useOrganization(user);
 
-  const { patients, deletePatient, bulkAddPatients, bulkDeletePatients } =
-    useSupabasePatients(userProfile?.organization_id);
+  const {
+    patients,
+    addPatient,
+    deletePatient,
+    bulkAddPatients,
+    bulkDeletePatients,
+    retryLoadPatients,
+  } = useSupabasePatients(userProfile?.organization_id);
 
   const { appointments, locations, loading: appointmentsLoading } = useAppointments();
 
@@ -297,6 +303,9 @@ export default function Appointments() {
         appointment={selectedAppointment}
         selectedTimeSlot={selectedTimeSlot}
         locations={locations}
+        patients={patients}
+        addPatient={addPatient}
+        retryLoadPatients={retryLoadPatients}
       />
       <SettingsModal
         isOpen={showSettings}


### PR DESCRIPTION
## Summary
- ensure AppointmentModal uses the same patient add flow as the main screen
- pass shared patient data and add helpers from Appointments page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892a72a387c8330b380703bcff38cf6