### PR TITLE
Ensure appointment end time exceeds start time

### DIFF
--- a/src/hooks/useAppointments.ts
+++ b/src/hooks/useAppointments.ts
@@ -64,6 +64,15 @@ export const useAppointments = () => {
   const createAppointment = async (appointmentData: AppointmentFormData) => {
     if (!user?.id || !userProfile?.organization_id) return;
 
+    if (appointmentData.end_time <= appointmentData.start_time) {
+      toast({
+        title: "Erro",
+        description: "O horário de término deve ser posterior ao horário de início.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     try {
       const { data, error } = await supabase
         .from('appointments')
@@ -98,6 +107,15 @@ export const useAppointments = () => {
   };
 
   const updateAppointment = async (id: string, appointmentData: AppointmentFormData) => {
+    if (appointmentData.end_time <= appointmentData.start_time) {
+      toast({
+        title: "Erro",
+        description: "O horário de término deve ser posterior ao horário de início.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     try {
       const updateData: any = { ...appointmentData };
       if (appointmentData.start_time) {

--- a/supabase/migrations/20250816120000-add-end-time-check.sql
+++ b/supabase/migrations/20250816120000-add-end-time-check.sql
@@ -1,0 +1,5 @@
+-- Ensure end time is always after start time for appointments
+ALTER TABLE public.appointments
+  DROP CONSTRAINT IF EXISTS appointments_end_time_after_start;
+ALTER TABLE public.appointments
+  ADD CONSTRAINT appointments_end_time_after_start CHECK (end_time > start_time);


### PR DESCRIPTION
## Summary
- validate appointment end time in AppointmentModal with Zod superRefine and submit guard
- prevent invalid times in appointment hooks
- enforce database constraint for end_time > start_time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6892abf3156c83308e5791b7dc2edf82