### PR TITLE
feat: add dynamic appointment titles

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -59,18 +59,13 @@ const appointmentSchema = z.object({
   recurrence_end_date: z.date().optional(),
 });
 
-const titleOptions = [
-  'Consulta de Retorno',
-  'Primeira Consulta', 
-  'Manutenção'
-];
-
 interface AppointmentModalProps {
   isOpen: boolean;
   onClose: () => void;
   appointment?: Appointment | null;
   selectedTimeSlot?: { date: Date; hour: number; minute: number } | null;
   locations: Location[];
+  titles: string[];
   patients: Patient[];
   addPatient: (
     patientData: PatientCreateData,
@@ -85,6 +80,7 @@ export function AppointmentModal({
   appointment,
   selectedTimeSlot,
   locations,
+  titles,
   patients,
   addPatient,
   retryLoadPatients,
@@ -384,7 +380,7 @@ export function AppointmentModal({
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {titleOptions.map((title) => (
+                      {(titles && titles.length > 0 ? titles : ['Consulta de Retorno']).map((title) => (
                         <SelectItem key={title} value={title}>
                           {title}
                         </SelectItem>

--- a/src/hooks/useAppointments.ts
+++ b/src/hooks/useAppointments.ts
@@ -8,6 +8,7 @@ import { useOrganization } from './useOrganization';
 export const useAppointments = () => {
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [locations, setLocations] = useState<Location[]>([]);
+  const [titles, setTitles] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
   const { user } = useAuth();
@@ -56,6 +57,29 @@ export const useAppointments = () => {
       toast({
         title: "Erro",
         description: "Não foi possível carregar os locais.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const fetchTitles = async () => {
+    if (!userProfile?.organization_id) return;
+
+    try {
+      const { data, error } = await supabase
+        .from('appointment_titles')
+        .select('title')
+        .eq('organization_id', userProfile.organization_id)
+        .eq('is_active', true)
+        .order('title');
+
+      if (error) throw error;
+      setTitles((data || []).map((t: { title: string }) => t.title));
+    } catch (error) {
+      console.error('Error fetching titles:', error);
+      toast({
+        title: "Erro",
+        description: "Não foi possível carregar os títulos.",
         variant: "destructive",
       });
     }
@@ -174,7 +198,7 @@ export const useAppointments = () => {
   useEffect(() => {
     if (userProfile?.organization_id) {
       setLoading(true);
-      Promise.all([fetchAppointments(), fetchLocations()]).finally(() => {
+      Promise.all([fetchAppointments(), fetchLocations(), fetchTitles()]).finally(() => {
         setLoading(false);
       });
     }
@@ -183,6 +207,7 @@ export const useAppointments = () => {
   return {
     appointments,
     locations,
+    titles,
     loading,
     createAppointment,
     updateAppointment,
@@ -190,5 +215,6 @@ export const useAppointments = () => {
     checkForConflicts,
     fetchAppointments,
     fetchLocations,
+    fetchTitles,
   };
 };

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -43,7 +43,7 @@ export default function Appointments() {
     retryLoadPatients,
   } = useSupabasePatients(userProfile?.organization_id);
 
-  const { appointments, locations, loading: appointmentsLoading } = useAppointments();
+  const { appointments, locations, titles, loading: appointmentsLoading } = useAppointments();
 
   const weekStart = startOfWeek(currentWeek, { weekStartsOn: 1 });
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
@@ -317,6 +317,7 @@ export default function Appointments() {
         appointment={selectedAppointment}
         selectedTimeSlot={selectedTimeSlot}
         locations={locations}
+        titles={titles}
         patients={patients}
         addPatient={addPatient}
         retryLoadPatients={retryLoadPatients}


### PR DESCRIPTION
## Summary
- fetch active appointment titles for organization in `useAppointments`
- pass retrieved titles into `AppointmentModal` for selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892acaba38883309e79a5290e501936