### PR TITLE
chore: refresh appointment settings

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -40,7 +40,7 @@ import {
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { DatePicker } from '@/components/ui/date-picker';
 import { useAppointments } from '@/hooks/useAppointments';
-import { Appointment, Location, AppointmentFormData } from '@/types/appointment';
+import { Appointment, Location, AppointmentFormData, AppointmentTitle } from '@/types/appointment';
 import { Patient, PatientCreateData } from '@/types/patient';
 import { PatientForm } from '@/components/PatientForm';
 import { useAuth } from '@/hooks/useAuth';
@@ -59,18 +59,13 @@ const appointmentSchema = z.object({
   recurrence_end_date: z.date().optional(),
 });
 
-const titleOptions = [
-  'Consulta de Retorno',
-  'Primeira Consulta', 
-  'Manutenção'
-];
-
 interface AppointmentModalProps {
   isOpen: boolean;
   onClose: () => void;
   appointment?: Appointment | null;
   selectedTimeSlot?: { date: Date; hour: number; minute: number } | null;
   locations: Location[];
+  titles: AppointmentTitle[];
   patients: Patient[];
   addPatient: (
     patientData: PatientCreateData,
@@ -85,6 +80,7 @@ export function AppointmentModal({
   appointment,
   selectedTimeSlot,
   locations,
+  titles,
   patients,
   addPatient,
   retryLoadPatients,
@@ -96,12 +92,14 @@ export function AppointmentModal({
   const { createAppointment, updateAppointment, deleteAppointment, checkForConflicts } = useAppointments();
   const { user } = useAuth();
 
+  const defaultTitle = titles.find(t => t.is_default)?.title || titles[0]?.title || 'Consulta de Retorno';
+
   const form = useForm<z.infer<typeof appointmentSchema>>({
     resolver: zodResolver(appointmentSchema),
     defaultValues: {
       patient_id: '',
       location_id: '',
-      title: 'Consulta de Retorno',
+      title: defaultTitle,
       date: new Date(),
       start_hour: 9,
       start_minute: 0,
@@ -144,7 +142,7 @@ export function AppointmentModal({
       form.reset({
         patient_id: '',
         location_id: locations[0]?.id || '',
-        title: 'Consulta de Retorno',
+        title: defaultTitle,
         date: selectedTimeSlot.date,
         start_hour: selectedTimeSlot.hour,
         start_minute: selectedTimeSlot.minute,
@@ -157,11 +155,11 @@ export function AppointmentModal({
     } else {
       // Creating new appointment without specific time
       const now = new Date();
-      
+
       form.reset({
         patient_id: '',
         location_id: locations[0]?.id || '',
-        title: 'Consulta de Retorno',
+        title: defaultTitle,
         date: now,
         start_hour: 9,
         start_minute: 0,
@@ -172,7 +170,7 @@ export function AppointmentModal({
       });
       setPatientSearch('');
     }
-  }, [appointment, selectedTimeSlot, locations, patients, form]);
+  }, [appointment, selectedTimeSlot, locations, patients, titles, form, defaultTitle]);
 
   useEffect(() => {
     if (watchedDate && watchedStartHour !== undefined && watchedStartMinute !== undefined && 
@@ -384,9 +382,9 @@ export function AppointmentModal({
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {titleOptions.map((title) => (
-                        <SelectItem key={title} value={title}>
-                          {title}
+                      {titles.map((t) => (
+                        <SelectItem key={t.id} value={t.title}>
+                          {t.title}
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -21,6 +21,8 @@ interface SettingsModalProps {
   onBulkImport: (patients: Omit<Patient, 'id' | 'contactHistory'>[]) => void;
   onDeletePatient: (patientId: string) => void;
   onBulkDelete: (patientIds: string[]) => void;
+  fetchLocations: () => Promise<void>;
+  fetchTitles: () => Promise<void>;
 }
 
 export const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -33,7 +35,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   onUpdateSettings,
   onBulkImport,
   onDeletePatient,
-  onBulkDelete
+  onBulkDelete,
+  fetchLocations,
+  fetchTitles
 }) => {
   const [showExcelImport, setShowExcelImport] = useState(false);
   const [showPatientRemoval, setShowPatientRemoval] = useState(false);
@@ -103,6 +107,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
               onUpdateSettings={onUpdateSettings}
               onShowExcelImport={() => setShowExcelImport(true)}
               onShowPatientRemoval={() => setShowPatientRemoval(true)}
+              fetchLocations={fetchLocations}
+              fetchTitles={fetchTitles}
             />
           </Tabs>
         )}

--- a/src/components/settings/AppointmentTitlesTab.tsx
+++ b/src/components/settings/AppointmentTitlesTab.tsx
@@ -22,7 +22,11 @@ interface AppointmentTitle {
   updated_at: string;
 }
 
-export const AppointmentTitlesTab: React.FC = () => {
+interface AppointmentTitlesTabProps {
+  fetchTitles: () => Promise<void>;
+}
+
+export const AppointmentTitlesTab: React.FC<AppointmentTitlesTabProps> = ({ fetchTitles }) => {
   const [titles, setTitles] = useState<AppointmentTitle[]>([]);
   const [loading, setLoading] = useState(true);
   const [newTitle, setNewTitle] = useState('');
@@ -81,6 +85,7 @@ export const AppointmentTitlesTab: React.FC = () => {
         title: "Sucesso",
         description: "Título adicionado com sucesso",
       });
+      fetchTitles();
     } catch (error) {
       console.error('Error adding title:', error);
       toast({
@@ -110,6 +115,7 @@ export const AppointmentTitlesTab: React.FC = () => {
         title: "Sucesso",
         description: "Título atualizado com sucesso",
       });
+      fetchTitles();
     } catch (error) {
       console.error('Error updating title:', error);
       toast({
@@ -133,11 +139,12 @@ export const AppointmentTitlesTab: React.FC = () => {
         ...t,
         is_default: t.id === titleId
       })));
-      
+
       toast({
         title: "Sucesso",
         description: "Título padrão atualizado",
       });
+      fetchTitles();
     } catch (error) {
       console.error('Error setting default title:', error);
       toast({
@@ -162,6 +169,7 @@ export const AppointmentTitlesTab: React.FC = () => {
         title: "Sucesso",
         description: "Título removido com sucesso",
       });
+      fetchTitles();
     } catch (error) {
       console.error('Error deleting title:', error);
       toast({

--- a/src/components/settings/LocationsTab.tsx
+++ b/src/components/settings/LocationsTab.tsx
@@ -23,7 +23,11 @@ interface Location {
   updated_at: string;
 }
 
-export const LocationsTab: React.FC = () => {
+interface LocationsTabProps {
+  fetchLocations: () => Promise<void>;
+}
+
+export const LocationsTab: React.FC<LocationsTabProps> = ({ fetchLocations }) => {
   const [locations, setLocations] = useState<Location[]>([]);
   const [loading, setLoading] = useState(true);
   const [newLocation, setNewLocation] = useState({ name: '', address: '' });
@@ -82,6 +86,7 @@ export const LocationsTab: React.FC = () => {
         title: "Sucesso",
         description: "Local adicionado com sucesso",
       });
+      fetchLocations();
     } catch (error) {
       console.error('Error adding location:', error);
       toast({
@@ -111,6 +116,7 @@ export const LocationsTab: React.FC = () => {
         title: "Sucesso",
         description: "Local atualizado com sucesso",
       });
+      fetchLocations();
     } catch (error) {
       console.error('Error updating location:', error);
       toast({
@@ -135,6 +141,7 @@ export const LocationsTab: React.FC = () => {
         title: "Sucesso",
         description: "Local removido com sucesso",
       });
+      fetchLocations();
     } catch (error) {
       console.error('Error deleting location:', error);
       toast({

--- a/src/components/settings/SettingsModalContent.tsx
+++ b/src/components/settings/SettingsModalContent.tsx
@@ -18,6 +18,8 @@ interface SettingsModalContentProps {
   onUpdateSettings: (updates: { whatsapp_default_message: string }) => void;
   onShowExcelImport: () => void;
   onShowPatientRemoval: () => void;
+  fetchLocations: () => Promise<void>;
+  fetchTitles: () => Promise<void>;
 }
 
 export const SettingsModalContent: React.FC<SettingsModalContentProps> = ({
@@ -27,7 +29,9 @@ export const SettingsModalContent: React.FC<SettingsModalContentProps> = ({
   onUpdateProfile,
   onUpdateSettings,
   onShowExcelImport,
-  onShowPatientRemoval
+  onShowPatientRemoval,
+  fetchLocations,
+  fetchTitles
 }) => {
   return (
     <div className="flex-1 overflow-y-auto p-6">
@@ -52,13 +56,13 @@ export const SettingsModalContent: React.FC<SettingsModalContentProps> = ({
 
       {isAdmin && (
         <TabsContent value="locations" className="space-y-4 mt-0">
-          <LocationsTab />
+          <LocationsTab fetchLocations={fetchLocations} />
         </TabsContent>
       )}
 
       {isAdmin && (
         <TabsContent value="titles" className="space-y-4 mt-0">
-          <AppointmentTitlesTab />
+          <AppointmentTitlesTab fetchTitles={fetchTitles} />
         </TabsContent>
       )}
 

--- a/src/hooks/useAppointments.ts
+++ b/src/hooks/useAppointments.ts
@@ -1,13 +1,14 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
-import { Appointment, Location, AppointmentFormData } from '@/types/appointment';
+import { Appointment, Location, AppointmentFormData, AppointmentTitle } from '@/types/appointment';
 import { useAuth } from './useAuth';
 import { useOrganization } from './useOrganization';
 
 export const useAppointments = () => {
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [locations, setLocations] = useState<Location[]>([]);
+  const [titles, setTitles] = useState<AppointmentTitle[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
   const { user } = useAuth();
@@ -56,6 +57,29 @@ export const useAppointments = () => {
       toast({
         title: "Erro",
         description: "Não foi possível carregar os locais.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const fetchTitles = async () => {
+    if (!userProfile?.organization_id) return;
+
+    try {
+      const { data, error } = await supabase
+        .from('appointment_titles')
+        .select('*')
+        .eq('organization_id', userProfile.organization_id)
+        .eq('is_active', true)
+        .order('title');
+
+      if (error) throw error;
+      setTitles((data || []) as AppointmentTitle[]);
+    } catch (error) {
+      console.error('Error fetching titles:', error);
+      toast({
+        title: "Erro",
+        description: "Não foi possível carregar os títulos.",
         variant: "destructive",
       });
     }
@@ -174,7 +198,7 @@ export const useAppointments = () => {
   useEffect(() => {
     if (userProfile?.organization_id) {
       setLoading(true);
-      Promise.all([fetchAppointments(), fetchLocations()]).finally(() => {
+      Promise.all([fetchAppointments(), fetchLocations(), fetchTitles()]).finally(() => {
         setLoading(false);
       });
     }
@@ -183,6 +207,7 @@ export const useAppointments = () => {
   return {
     appointments,
     locations,
+    titles,
     loading,
     createAppointment,
     updateAppointment,
@@ -190,5 +215,6 @@ export const useAppointments = () => {
     checkForConflicts,
     fetchAppointments,
     fetchLocations,
+    fetchTitles,
   };
 };

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -43,7 +43,7 @@ export default function Appointments() {
     retryLoadPatients,
   } = useSupabasePatients(userProfile?.organization_id);
 
-  const { appointments, locations, loading: appointmentsLoading } = useAppointments();
+  const { appointments, locations, titles, loading: appointmentsLoading, fetchLocations, fetchTitles } = useAppointments();
 
   const weekStart = startOfWeek(currentWeek, { weekStartsOn: 1 });
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
@@ -317,6 +317,7 @@ export default function Appointments() {
         appointment={selectedAppointment}
         selectedTimeSlot={selectedTimeSlot}
         locations={locations}
+        titles={titles}
         patients={patients}
         addPatient={addPatient}
         retryLoadPatients={retryLoadPatients}
@@ -332,6 +333,8 @@ export default function Appointments() {
         onBulkImport={bulkAddPatients}
         onDeletePatient={deletePatient}
         onBulkDelete={bulkDeletePatients}
+        fetchLocations={fetchLocations}
+        fetchTitles={fetchTitles}
       />
     </div>
   </div>

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -41,3 +41,10 @@ export interface AppointmentFormData {
   recurrence_type: 'none' | 'monthly' | 'semiannual' | 'annual';
   recurrence_end_date?: Date;
 }
+
+export interface AppointmentTitle {
+  id: string;
+  title: string;
+  is_active: boolean;
+  is_default: boolean;
+}


### PR DESCRIPTION
## Summary
- expose location and title refresh callbacks through settings modal
- update settings tabs to refetch locations and titles after changes
- support dynamic appointment titles in appointment form

## Testing
- `npm run lint` *(fails: userApprovalService.ts, userProfileService.ts, migrationUtils.ts, patientConverters.ts, tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6892acb3dbc88330942200fa6c96ed36