### PR TITLE
Remove obligatory next contact reason

### DIFF
--- a/src/components/PatientForm.tsx
+++ b/src/components/PatientForm.tsx
@@ -79,7 +79,7 @@ export const PatientForm: React.FC<PatientFormProps> = ({ patient, onSave, onCan
     handleChange('nextContactDate', nextDate);
   };
 
-  const isFormValid = formData.name && formData.phone && formData.nextContactReason;
+  const isFormValid = formData.name && formData.phone;
 
   return (
     <Dialog open={true} onOpenChange={onCancel}>

--- a/src/components/patient-form/PatientFormFields.tsx
+++ b/src/components/patient-form/PatientFormFields.tsx
@@ -67,14 +67,13 @@ export const PatientFormFields: React.FC<PatientFormFieldsProps> = ({
       />
 
       <div>
-        <Label htmlFor="nextContactReason">Motivo do Próximo Contato *</Label>
+        <Label htmlFor="nextContactReason">Motivo do Próximo Contato</Label>
         <Textarea
           id="nextContactReason"
           value={formData.nextContactReason}
           onChange={(e) => onChange('nextContactReason', e.target.value)}
           placeholder="Ex: Limpeza, revisão, tratamento..."
           rows={2}
-          required
         />
       </div>
 

--- a/src/utils/patientConverters.ts
+++ b/src/utils/patientConverters.ts
@@ -70,7 +70,7 @@ export const assertDatabasePatient = (data: any): DatabasePatient => {
     throw new Error('Invalid patient data: not an object');
   }
 
-  const required = ['id', 'name', 'phone', 'last_visit', 'next_contact_reason', 'next_contact_date', 'user_id'];
+  const required = ['id', 'name', 'phone', 'last_visit', 'next_contact_date', 'user_id'];
   for (const field of required) {
     if (!data[field]) {
       throw new Error(`Invalid patient data: missing ${field}`);


### PR DESCRIPTION
## Summary
- make "Motivo do Próximo Contato" optional in patient form
- relax database patient assertion to not require `next_contact_reason`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892bc39d7d48330ac962f765350b1b3