### PR TITLE
Use abbreviated weekday names in agenda

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -260,7 +260,7 @@ export default function Appointments() {
                   key={day.toISOString()}
                   className={`${weekend ? 'bg-muted/20 text-muted-foreground/50' : 'bg-muted'} p-2 border-r text-center`}
                 >
-                  <div className="font-medium">{format(day, 'EEE', { locale: ptBR })}</div>
+                  <div className="font-medium">{format(day, 'EEEEEE', { locale: ptBR })}</div>
                   <div className={`text-sm ${weekend ? 'text-muted-foreground/50' : 'text-muted-foreground'}`}>{format(day, 'd')}</div>
                 </div>
               );


### PR DESCRIPTION
## Summary
- show 3-letter weekday names in agenda header

## Testing
- `npm run lint` *(fails: Unexpected any, etc)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897ce7bf1ac83309837e14e10ce7c2d