### PR TITLE
feat: configurable working hours for agenda

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -17,7 +17,9 @@ interface SettingsModalProps {
   organizationSettings: OrganizationSettings | null;
   patients: Patient[];
   onUpdateProfile: (updates: { name: string }) => void;
-  onUpdateSettings: (updates: { whatsapp_default_message: string }) => void;
+  onUpdateSettings: (
+    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+  ) => void;
   onBulkImport: (patientsData: Omit<Patient, 'id' | 'contactHistory'>[], userId: string) => Promise<number>;
   onDeletePatient: (patientId: string) => void;
   onBulkDelete: (patientIds: string[]) => void;

--- a/src/components/settings/SettingsModalContent.tsx
+++ b/src/components/settings/SettingsModalContent.tsx
@@ -8,6 +8,7 @@ import { RemovalTab } from '@/components/settings/RemovalTab';
 import { LocationsTab } from '@/components/settings/LocationsTab';
 import { AppointmentTitlesTab } from '@/components/settings/AppointmentTitlesTab';
 import { UserManagement } from '@/components/UserManagement';
+import { WorkingHoursTab } from '@/components/settings/WorkingHoursTab';
 import { UserProfile, OrganizationSettings } from '@/types/organization';
 
 interface SettingsModalContentProps {
@@ -15,7 +16,9 @@ interface SettingsModalContentProps {
   organizationSettings: OrganizationSettings | null;
   isAdmin: boolean;
   onUpdateProfile: (updates: { name: string }) => void;
-  onUpdateSettings: (updates: { whatsapp_default_message: string }) => void;
+  onUpdateSettings: (
+    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+  ) => void;
   onShowExcelImport: () => void;
   onShowPatientRemoval: () => void;
   fetchLocations: () => Promise<void>;
@@ -53,6 +56,15 @@ export const SettingsModalContent: React.FC<SettingsModalContentProps> = ({
           onUpdateSettings={onUpdateSettings}
         />
       </TabsContent>
+
+      {isAdmin && (
+        <TabsContent value="hours" className="space-y-4 mt-0">
+          <WorkingHoursTab
+            organizationSettings={organizationSettings}
+            onUpdateSettings={onUpdateSettings}
+          />
+        </TabsContent>
+      )}
 
       {isAdmin && (
         <TabsContent value="locations" className="space-y-4 mt-0">

--- a/src/components/settings/SettingsModalSidebar.tsx
+++ b/src/components/settings/SettingsModalSidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Building2, User, MessageSquare, FileSpreadsheet, Trash2, Users, MapPin, Tag } from 'lucide-react';
+import { Building2, User, MessageSquare, FileSpreadsheet, Trash2, Users, MapPin, Tag, Clock } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-mobile';
 
 interface SettingsModalSidebarProps {
@@ -19,8 +19,8 @@ export const SettingsModalSidebar: React.FC<SettingsModalSidebarProps> = ({ isAd
       flex-shrink-0
     `}>
       <TabsList className={`
-        ${isMobile 
-          ? 'grid grid-cols-7 w-full h-auto bg-muted/50 p-1 gap-1' 
+        ${isMobile
+          ? 'grid grid-cols-9 w-full h-auto bg-muted/50 p-1 gap-1'
           : 'flex flex-col h-full w-full bg-transparent p-1 gap-1'
         }
       `}>
@@ -63,9 +63,9 @@ export const SettingsModalSidebar: React.FC<SettingsModalSidebarProps> = ({ isAd
             </span>
           )}
         </TabsTrigger>
-        
-        <TabsTrigger 
-          value="whatsapp" 
+
+        <TabsTrigger
+          value="whatsapp"
           className={`
             ${isMobile 
               ? 'flex flex-col items-center justify-center p-2 h-16 text-xs' 
@@ -85,11 +85,33 @@ export const SettingsModalSidebar: React.FC<SettingsModalSidebarProps> = ({ isAd
         </TabsTrigger>
         
         {isAdmin && (
-          <TabsTrigger 
-            value="locations" 
+          <TabsTrigger
+            value="hours"
             className={`
-              ${isMobile 
-                ? 'flex flex-col items-center justify-center p-2 h-16 text-xs' 
+              ${isMobile
+                ? 'flex flex-col items-center justify-center p-2 h-16 text-xs'
+                : 'flex items-center justify-start p-3 h-12 w-full overflow-hidden hover:bg-accent/50 data-[state=active]:bg-accent'
+              }
+            `}
+            title="Horários"
+          >
+            <Clock className={isMobile ? "w-4 h-4 mb-1" : "w-5 h-5 flex-shrink-0"} />
+            {isMobile ? (
+              <span className="text-xs leading-tight">Horas</span>
+            ) : (
+              <span className="ml-3 text-sm whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                Horários
+              </span>
+            )}
+          </TabsTrigger>
+        )}
+
+        {isAdmin && (
+          <TabsTrigger
+            value="locations"
+            className={`
+              ${isMobile
+                ? 'flex flex-col items-center justify-center p-2 h-16 text-xs'
                 : 'flex items-center justify-start p-3 h-12 w-full overflow-hidden hover:bg-accent/50 data-[state=active]:bg-accent'
               }
             `}

--- a/src/components/settings/WorkingHoursTab.tsx
+++ b/src/components/settings/WorkingHoursTab.tsx
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { OrganizationSettings } from '@/types/organization';
+
+interface WorkingHoursTabProps {
+  organizationSettings: OrganizationSettings | null;
+  onUpdateSettings: (
+    updates: Partial<Pick<OrganizationSettings, 'working_hours_start' | 'working_hours_end'>>
+  ) => void;
+}
+
+export const WorkingHoursTab: React.FC<WorkingHoursTabProps> = ({
+  organizationSettings,
+  onUpdateSettings,
+}) => {
+  const [start, setStart] = useState<number>(organizationSettings?.working_hours_start ?? 9);
+  const [end, setEnd] = useState<number>(organizationSettings?.working_hours_end ?? 18);
+
+  useEffect(() => {
+    setStart(organizationSettings?.working_hours_start ?? 9);
+    setEnd(organizationSettings?.working_hours_end ?? 18);
+  }, [organizationSettings]);
+
+  const hours = Array.from({ length: 24 }, (_, i) => i);
+
+  const handleSave = () => {
+    if (start < end) {
+      onUpdateSettings({ working_hours_start: start, working_hours_end: end });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-dental-primary">Horários da Agenda</CardTitle>
+        <CardDescription>
+          Defina o intervalo de horários úteis visíveis na agenda
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex gap-4">
+          <div className="flex-1">
+            <Label>Início</Label>
+            <Select value={start.toString()} onValueChange={(v) => setStart(Number(v))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {hours.map((h) => (
+                  <SelectItem key={h} value={h.toString()}>
+                    {`${h.toString().padStart(2, '0')}:00`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex-1">
+            <Label>Fim</Label>
+            <Select value={end.toString()} onValueChange={(v) => setEnd(Number(v))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {hours.map((h) => (
+                  <SelectItem key={h} value={h.toString()}>
+                    {`${h.toString().padStart(2, '0')}:00`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <Button onClick={handleSave} disabled={start >= end}>
+          Salvar
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -145,7 +145,9 @@ export const useOrganization = (user: User | null) => {
     }
   };
 
-  const updateOrganizationSettings = async (updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message'>>) => {
+  const updateOrganizationSettings = async (
+    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+  ) => {
     if (!userProfile?.organization_id) return;
 
     try {

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -75,7 +75,10 @@ export default function Appointments() {
   const weekDays = getWeekDays(currentWeek);
   const filteredWeekDays = weekDays.filter(day => !isWeekend(day));
   const allHours = Array.from({ length: 96 }, (_, i) => i / 4); // 15 min increments
-  const workingHours = { start: 9, end: 18 }; // 9:00 to 18:00
+  const workingHours = {
+    start: organizationSettings?.working_hours_start ?? 9,
+    end: organizationSettings?.working_hours_end ?? 18,
+  };
   const scrollTargetHour = 8; // Scroll to 8:00 on load
   const scheduleRef = useRef<HTMLDivElement>(null);
   const firstHourRef = useRef<HTMLDivElement>(null);
@@ -181,7 +184,7 @@ export default function Appointments() {
       onSettingsClick={() => setShowSettings(true)}
       onSignOut={signOut}
     >
-      <div className="container mx-auto max-w-7xl h-full flex flex-col gap-6">
+      <div className="container mx-auto max-w-7xl flex flex-col gap-6 h-[calc(100vh-8rem)] overflow-hidden">
 
         {/* Header */}
         <div className="mb-8">

--- a/src/services/organizationSettingsService.ts
+++ b/src/services/organizationSettingsService.ts
@@ -26,7 +26,10 @@ export class OrganizationSettingsService {
     }
   }
 
-  static async updateOrganizationSettings(organizationId: string, updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message'>>): Promise<void> {
+  static async updateOrganizationSettings(
+    organizationId: string,
+    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+  ): Promise<void> {
     console.log('📝 OrganizationSettingsService.updateOrganizationSettings:', { organizationId, updates });
     
     const { error } = await supabase
@@ -48,10 +51,15 @@ export class OrganizationSettingsService {
     
     const { error } = await supabase
       .from('organization_settings')
-      .insert([{
-        organization_id: organizationId,
-        whatsapp_default_message: 'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!'
-      }])
+      .insert([
+        {
+          organization_id: organizationId,
+          whatsapp_default_message:
+            'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!',
+          working_hours_start: 9,
+          working_hours_end: 18,
+        },
+      ])
       .select();
 
     if (error) {

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -22,6 +22,8 @@ export interface OrganizationSettings {
   id: string;
   organization_id: string;
   whatsapp_default_message: string;
+  working_hours_start: number;
+  working_hours_end: number;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- allow admins to define working hours shown in schedule
- add schedule hours tab in settings
- constrain agenda to internal vertical scroll

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any types and require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897d60ff288833099d9664ad2cd4a36