### PR TITLE
Enforce user approval status for organization access

### DIFF
--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -6,6 +6,7 @@ import { UserProfileService } from '@/services/userProfileService';
 import { OrganizationSettingsService } from '@/services/organizationSettingsService';
 import { useToast } from '@/hooks/use-toast';
 import { User } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase/client';
 
 export const useOrganization = (user: User | null) => {
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
@@ -34,7 +35,20 @@ export const useOrganization = (user: User | null) => {
       
       const profile = await UserProfileService.getUserProfile(user.id);
       console.log('✅ User profile loaded:', profile);
-      
+
+      if (profile?.status === 'rejected') {
+        console.log('🚫 User profile rejected, signing out');
+        await supabase.auth.signOut();
+        toast({
+          title: "Acesso negado",
+          description: "Sua solicitação de acesso foi rejeitada pelo administrador.",
+          variant: "destructive",
+        });
+        resetState();
+        setLoading(false);
+        return;
+      }
+
       setUserProfile(profile);
 
       if (profile?.organization_id) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -190,46 +190,75 @@ const Index = () => {
 
   return (
     <AuthGuard>
-      {!userProfile || userProfile.status === 'pending' ? (
-        userProfile?.status === 'pending' ? (
-          <div className="min-h-screen bg-gradient-to-br from-dental-background via-white to-dental-accent flex items-center justify-center p-4">
-            {/* Cabeçalho com e-mail e botão sair para usuários pending */}
-            <div className="fixed top-4 right-4 z-50 flex items-center gap-2">
-              <span className="text-sm text-dental-secondary bg-white/80 px-2 py-1 rounded">
-                {user?.email}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={signOut}
-                className="border-dental-primary text-dental-primary hover:bg-dental-primary hover:text-white"
-              >
-                Sair
-              </Button>
-            </div>
-            
-            <Card className="w-full max-w-md">
-              <CardContent className="p-6 text-center">
-                <Clock className="w-12 h-12 mx-auto text-dental-secondary mb-4" />
-                <h2 className="text-xl font-semibold text-dental-primary mb-2">
-                  Aguardando Aprovação
-                </h2>
-                <p className="text-dental-secondary mb-4">
-                  Sua solicitação de acesso foi enviada e está aguardando aprovação do administrador.
-                </p>
-                <Button onClick={signOut} variant="outline">
-                  Fazer logout
-                </Button>
-              </CardContent>
-            </Card>
+      {!userProfile ? (
+        <OnboardingFlow
+          onCreateOrganization={createOrganization}
+          onJoinOrganization={joinOrganization}
+          userEmail={user?.email}
+        />
+      ) : userProfile.status === 'pending' ? (
+        <div className="min-h-screen bg-gradient-to-br from-dental-background via-white to-dental-accent flex items-center justify-center p-4">
+          {/* Cabeçalho com e-mail e botão sair para usuários pending */}
+          <div className="fixed top-4 right-4 z-50 flex items-center gap-2">
+            <span className="text-sm text-dental-secondary bg-white/80 px-2 py-1 rounded">
+              {user?.email}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={signOut}
+              className="border-dental-primary text-dental-primary hover:bg-dental-primary hover:text-white"
+            >
+              Sair
+            </Button>
           </div>
-        ) : (
-          <OnboardingFlow 
-            onCreateOrganization={createOrganization}
-            onJoinOrganization={joinOrganization}
-            userEmail={user?.email}
-          />
-        )
+
+          <Card className="w-full max-w-md">
+            <CardContent className="p-6 text-center">
+              <Clock className="w-12 h-12 mx-auto text-dental-secondary mb-4" />
+              <h2 className="text-xl font-semibold text-dental-primary mb-2">
+                Aguardando Aprovação
+              </h2>
+              <p className="text-dental-secondary mb-4">
+                Sua solicitação de acesso foi enviada e está aguardando aprovação do administrador.
+              </p>
+              <Button onClick={signOut} variant="outline">
+                Fazer logout
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      ) : userProfile.status === 'rejected' ? (
+        <div className="min-h-screen bg-gradient-to-br from-dental-background via-white to-dental-accent flex items-center justify-center p-4">
+          <div className="fixed top-4 right-4 z-50 flex items-center gap-2">
+            <span className="text-sm text-dental-secondary bg-white/80 px-2 py-1 rounded">
+              {user?.email}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={signOut}
+              className="border-dental-primary text-dental-primary hover:bg-dental-primary hover:text-white"
+            >
+              Sair
+            </Button>
+          </div>
+
+          <Card className="w-full max-w-md">
+            <CardContent className="p-6 text-center">
+              <AlertCircle className="w-12 h-12 mx-auto text-red-500 mb-4" />
+              <h2 className="text-xl font-semibold text-dental-primary mb-2">
+                Acesso Negado
+              </h2>
+              <p className="text-dental-secondary mb-4">
+                Seu acesso foi rejeitado pelo administrador.
+              </p>
+              <Button onClick={signOut} variant="outline">
+                Fazer logout
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
       ) : (
         <AppNavigation
           userProfile={userProfile}

--- a/supabase/migrations/20250824120000-update-user-belongs-status-check.sql
+++ b/supabase/migrations/20250824120000-update-user-belongs-status-check.sql
@@ -1,0 +1,14 @@
+-- Update user_belongs_to_organization function to check user status
+CREATE OR REPLACE FUNCTION public.user_belongs_to_organization(org_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.user_profiles
+    WHERE user_id = auth.uid()
+      AND organization_id = org_id
+      AND status = 'approved'
+  );
+$$;


### PR DESCRIPTION
## Summary
- sign out users whose profiles were rejected
- block unapproved users at the database level
- show dedicated message when account access is rejected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type, A `require()` style import is forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d92ad29c83308a03c2a44ed1dfea