### PR TITLE
fix: allow fractional working hours

### DIFF
--- a/src/components/settings/WorkingHoursTab.tsx
+++ b/src/components/settings/WorkingHoursTab.tsx
@@ -24,7 +24,16 @@ export const WorkingHoursTab: React.FC<WorkingHoursTabProps> = ({
     setEnd(organizationSettings?.working_hours_end ?? 18);
   }, [organizationSettings]);
 
-  const hours = Array.from({ length: 24 }, (_, i) => i);
+  // Generate 15 minute increments across 24 hours (0, 0.25, ..., 23.75)
+  const hours = Array.from({ length: 24 * 4 }, (_, i) => i * 0.25);
+
+  const formatHour = (hour: number) => {
+    const h = Math.floor(hour).toString().padStart(2, '0');
+    const m = Math.round((hour % 1) * 60)
+      .toString()
+      .padStart(2, '0');
+    return `${h}:${m}`;
+  };
 
   const handleSave = () => {
     if (start < end) {
@@ -51,7 +60,7 @@ export const WorkingHoursTab: React.FC<WorkingHoursTabProps> = ({
               <SelectContent>
                 {hours.map((h) => (
                   <SelectItem key={h} value={h.toString()}>
-                    {`${h.toString().padStart(2, '0')}:00`}
+                    {formatHour(h)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -66,7 +75,7 @@ export const WorkingHoursTab: React.FC<WorkingHoursTabProps> = ({
               <SelectContent>
                 {hours.map((h) => (
                   <SelectItem key={h} value={h.toString()}>
-                    {`${h.toString().padStart(2, '0')}:00`}
+                    {formatHour(h)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/services/organizationSettingsService.ts
+++ b/src/services/organizationSettingsService.ts
@@ -31,18 +31,38 @@ export class OrganizationSettingsService {
     updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
   ): Promise<void> {
     console.log('📝 OrganizationSettingsService.updateOrganizationSettings:', { organizationId, updates });
-    
+    const defaultMessage =
+      'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!';
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('organization_settings')
+      .select('*')
+      .eq('organization_id', organizationId)
+      .maybeSingle();
+
+    if (fetchError) {
+      console.error('❌ Error fetching organization settings before update:', fetchError);
+      throw fetchError;
+    }
+
+    const payload = {
+      organization_id: organizationId,
+      whatsapp_default_message:
+        updates.whatsapp_default_message ?? existing?.whatsapp_default_message ?? defaultMessage,
+      working_hours_start: updates.working_hours_start ?? existing?.working_hours_start ?? 9,
+      working_hours_end: updates.working_hours_end ?? existing?.working_hours_end ?? 18,
+    };
+
     const { error } = await supabase
       .from('organization_settings')
-      .update(updates)
-      .eq('organization_id', organizationId)
+      .upsert(payload, { onConflict: 'organization_id' })
       .select();
 
     if (error) {
       console.error('❌ Error updating organization settings:', error);
       throw error;
     }
-    
+
     console.log('✅ Organization settings updated');
   }
 


### PR DESCRIPTION
## Summary
- allow selecting 15-minute increments for agenda working hours
- ensure organization settings are created when updating working hours

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: React project has pre-existing lint errors)
- `npx eslint src/components/settings/WorkingHoursTab.tsx src/services/organizationSettingsService.ts`

------
https://chatgpt.com/codex/tasks/task_e_6897e0b5c658833096bc1b1bdffc19c9