### PR TITLE
feat: highlight and confirm schedule conflicts

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -233,6 +233,11 @@ export function AppointmentModal({
         return;
       }
 
+      if (conflicts.length > 0) {
+        const proceed = window.confirm('Existem conflitos de horário. Deseja continuar?');
+        if (!proceed) return;
+      }
+
       const appointmentData: AppointmentFormData = {
         patient_id: data.patient_id,
         location_id: data.location_id,


### PR DESCRIPTION
## Summary
- highlight conflicting appointments side-by-side with warning ring
- ask for user confirmation before saving overlapping appointments

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6897e20debdc8330a20b8636b8037b6d