### PR TITLE
fix: parse working hour values

### DIFF
--- a/src/components/settings/WorkingHoursTab.tsx
+++ b/src/components/settings/WorkingHoursTab.tsx
@@ -16,12 +16,16 @@ export const WorkingHoursTab: React.FC<WorkingHoursTabProps> = ({
   organizationSettings,
   onUpdateSettings,
 }) => {
-  const [start, setStart] = useState<number>(organizationSettings?.working_hours_start ?? 9);
-  const [end, setEnd] = useState<number>(organizationSettings?.working_hours_end ?? 18);
+  const [start, setStart] = useState<number>(
+    Number(organizationSettings?.working_hours_start ?? 9)
+  );
+  const [end, setEnd] = useState<number>(
+    Number(organizationSettings?.working_hours_end ?? 18)
+  );
 
   useEffect(() => {
-    setStart(organizationSettings?.working_hours_start ?? 9);
-    setEnd(organizationSettings?.working_hours_end ?? 18);
+    setStart(Number(organizationSettings?.working_hours_start ?? 9));
+    setEnd(Number(organizationSettings?.working_hours_end ?? 18));
   }, [organizationSettings]);
 
   // Generate 15 minute increments across 24 hours (0, 0.25, ..., 23.75)

--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -56,7 +56,15 @@ export const useOrganization = (user: User | null) => {
         try {
           const settings = await OrganizationSettingsService.getOrganizationSettings(profile.organization_id);
           console.log('✅ Organization settings loaded:', settings);
-          setOrganizationSettings(settings);
+          setOrganizationSettings(
+            settings
+              ? {
+                  ...settings,
+                  working_hours_start: Number(settings.working_hours_start),
+                  working_hours_end: Number(settings.working_hours_end),
+                }
+              : null
+          );
         } catch (settingsError) {
           console.warn('⚠️ Failed to load organization settings, but continuing:', settingsError);
           setOrganizationSettings(null);

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -76,8 +76,8 @@ export default function Appointments() {
   const filteredWeekDays = weekDays.filter(day => !isWeekend(day));
   const allHours = Array.from({ length: 96 }, (_, i) => i / 4); // 15 min increments
   const workingHours = {
-    start: organizationSettings?.working_hours_start ?? 9,
-    end: organizationSettings?.working_hours_end ?? 18,
+    start: Number(organizationSettings?.working_hours_start ?? 9),
+    end: Number(organizationSettings?.working_hours_end ?? 18),
   };
   const scrollTargetHour = 8; // Scroll to 8:00 on load
   const scheduleRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- ensure working hours numeric values are parsed from organization settings
- update working hours tab to treat values as numbers
- interpret working hours as numbers on appointments page

## Testing
- `npm run lint` *(fails: Unexpected any / forbidden require)*

------
https://chatgpt.com/codex/tasks/task_e_6897e2d272188330a189bba8ec01f586