### PR TITLE
Set default working hours to 8-18 and fix Supabase schema

### DIFF
--- a/src/components/settings/WorkingHoursTab.tsx
+++ b/src/components/settings/WorkingHoursTab.tsx
@@ -17,14 +17,14 @@ export const WorkingHoursTab: React.FC<WorkingHoursTabProps> = ({
   onUpdateSettings,
 }) => {
   const [start, setStart] = useState<number>(
-    Number(organizationSettings?.working_hours_start ?? 9)
+    Number(organizationSettings?.working_hours_start ?? 8)
   );
   const [end, setEnd] = useState<number>(
     Number(organizationSettings?.working_hours_end ?? 18)
   );
 
   useEffect(() => {
-    setStart(Number(organizationSettings?.working_hours_start ?? 9));
+    setStart(Number(organizationSettings?.working_hours_start ?? 8));
     setEnd(Number(organizationSettings?.working_hours_end ?? 18));
   }, [organizationSettings]);
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -210,6 +210,8 @@ export type Database = {
           organization_id: string
           updated_at: string
           whatsapp_default_message: string | null
+          working_hours_start: number | null
+          working_hours_end: number | null
         }
         Insert: {
           created_at?: string
@@ -217,6 +219,8 @@ export type Database = {
           organization_id: string
           updated_at?: string
           whatsapp_default_message?: string | null
+          working_hours_start?: number | null
+          working_hours_end?: number | null
         }
         Update: {
           created_at?: string
@@ -224,6 +228,8 @@ export type Database = {
           organization_id?: string
           updated_at?: string
           whatsapp_default_message?: string | null
+          working_hours_start?: number | null
+          working_hours_end?: number | null
         }
         Relationships: [
           {

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -76,7 +76,7 @@ export default function Appointments() {
   const filteredWeekDays = weekDays.filter(day => !isWeekend(day));
   const allHours = Array.from({ length: 96 }, (_, i) => i / 4); // 15 min increments
   const workingHours = {
-    start: Number(organizationSettings?.working_hours_start ?? 9),
+    start: Number(organizationSettings?.working_hours_start ?? 8),
     end: Number(organizationSettings?.working_hours_end ?? 18),
   };
   const scrollTargetHour = 8; // Scroll to 8:00 on load

--- a/src/services/organizationSettingsService.ts
+++ b/src/services/organizationSettingsService.ts
@@ -49,7 +49,7 @@ export class OrganizationSettingsService {
       organization_id: organizationId,
       whatsapp_default_message:
         updates.whatsapp_default_message ?? existing?.whatsapp_default_message ?? defaultMessage,
-      working_hours_start: updates.working_hours_start ?? existing?.working_hours_start ?? 9,
+      working_hours_start: updates.working_hours_start ?? existing?.working_hours_start ?? 8,
       working_hours_end: updates.working_hours_end ?? existing?.working_hours_end ?? 18,
     };
 
@@ -76,7 +76,7 @@ export class OrganizationSettingsService {
           organization_id: organizationId,
           whatsapp_default_message:
             'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!',
-          working_hours_start: 9,
+          working_hours_start: 8,
           working_hours_end: 18,
         },
       ])

--- a/supabase/migrations/20250830080000-add-working-hours-to-organization-settings.sql
+++ b/supabase/migrations/20250830080000-add-working-hours-to-organization-settings.sql
@@ -1,0 +1,25 @@
+-- Add working hours columns and policies to organization_settings
+ALTER TABLE IF EXISTS public.organization_settings
+  ADD COLUMN IF NOT EXISTS working_hours_start numeric NOT NULL DEFAULT 8,
+  ADD COLUMN IF NOT EXISTS working_hours_end numeric NOT NULL DEFAULT 18;
+
+-- Ensure row level security is enabled
+ALTER TABLE public.organization_settings ENABLE ROW LEVEL SECURITY;
+
+-- Allow members to read their organization's settings
+CREATE POLICY IF NOT EXISTS "organization_settings_select_user_org"
+  ON public.organization_settings
+  FOR SELECT
+  USING (organization_id = get_user_organization_id());
+
+-- Allow members to insert settings for their organization
+CREATE POLICY IF NOT EXISTS "organization_settings_insert_user_org"
+  ON public.organization_settings
+  FOR INSERT
+  WITH CHECK (organization_id = get_user_organization_id());
+
+-- Allow members to update settings for their organization
+CREATE POLICY IF NOT EXISTS "organization_settings_update_user_org"
+  ON public.organization_settings
+  FOR UPDATE
+  USING (organization_id = get_user_organization_id());


### PR DESCRIPTION
## Summary
- default working hours to 08:00–18:00 across services, pages and settings
- add Supabase migration and types for working hour columns and RLS policies

## Testing
- `npm run lint` *(fails: Unexpected any in various files)*

------
https://chatgpt.com/codex/tasks/task_e_6897e61157308330aec8f90e803e4bbd