### PR TITLE
fix: handle null working hours

### DIFF
--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -60,8 +60,14 @@ export const useOrganization = (user: User | null) => {
             settings
               ? {
                   ...settings,
-                  working_hours_start: Number(settings.working_hours_start),
-                  working_hours_end: Number(settings.working_hours_end),
+                  working_hours_start:
+                    settings.working_hours_start !== null
+                      ? Number(settings.working_hours_start)
+                      : null,
+                  working_hours_end:
+                    settings.working_hours_end !== null
+                      ? Number(settings.working_hours_end)
+                      : null,
                 }
               : null
           );

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -22,8 +22,8 @@ export interface OrganizationSettings {
   id: string;
   organization_id: string;
   whatsapp_default_message: string;
-  working_hours_start: number;
-  working_hours_end: number;
+  working_hours_start: number | null;
+  working_hours_end: number | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- handle null working hours in `useOrganization`
- allow working hour fields to be null in `OrganizationSettings`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 15 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897e970b5d08330bcbdd645c428c55f