### PR TITLE
Fix agenda hour column alignment

### DIFF
--- a/src/components/schedule/WeekSchedule.tsx
+++ b/src/components/schedule/WeekSchedule.tsx
@@ -173,7 +173,7 @@ export function WeekSchedule(props: WeekScheduleProps) {
               <div
                 key={slotIndex}
                 ref={attachRef ? firstHourRef : undefined}
-                className={`p-2 text-[10px] sm:text-xs text-center ${isHourBoundary ? 'border-b' : ''} ${isWorking ? 'bg-muted/50 text-muted-foreground' : 'bg-muted/20 text-muted-foreground/50'}`}
+                className={`px-2 py-1 text-[10px] sm:text-xs text-center ${isHourBoundary ? 'border-b' : ''} ${isWorking ? 'bg-muted/50 text-muted-foreground' : 'bg-muted/20 text-muted-foreground/50'}`}
                 style={{ height: SLOT_HEIGHT_PX }}
               >
                 {isHourBoundary ? formatHour(slotHour) : ''}


### PR DESCRIPTION
## Summary
- fix misalignment between hour and day columns in agenda by reducing time column padding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any & forbidden require in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6898e588d70c833092690d4ab27eca13