### PR TITLE
feat: add consultations tab to patient form

### DIFF
--- a/src/components/PatientAppointments.tsx
+++ b/src/components/PatientAppointments.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { usePatientAppointments } from '@/hooks/usePatientAppointments';
+import { Card, CardContent } from '@/components/ui/card';
+import { Calendar, Clock } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+interface PatientAppointmentsProps {
+  patientId: string;
+}
+
+export const PatientAppointments: React.FC<PatientAppointmentsProps> = ({ patientId }) => {
+  const { appointments, loading } = usePatientAppointments(patientId);
+
+  if (loading) {
+    return <p className="text-sm text-dental-secondary p-4">Carregando...</p>;
+  }
+
+  if (appointments.length === 0) {
+    return <p className="text-sm text-dental-secondary p-4">Nenhuma consulta encontrada.</p>;
+  }
+
+  return (
+    <div className="space-y-3 p-1">
+      {appointments.map(appointment => (
+        <Card key={appointment.id}>
+          <CardContent className="p-3">
+            <div className="font-medium text-dental-primary">{appointment.title}</div>
+            <div className="flex items-center gap-2 text-sm text-dental-secondary mt-1">
+              <Calendar className="w-4 h-4" />
+              <span>{format(new Date(appointment.start_time), 'dd/MM/yyyy', { locale: ptBR })}</span>
+              <Clock className="w-4 h-4 ml-2" />
+              <span>
+                {format(new Date(appointment.start_time), 'HH:mm', { locale: ptBR })} -
+                {format(new Date(appointment.end_time), 'HH:mm', { locale: ptBR })}
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/src/components/PatientForm.tsx
+++ b/src/components/PatientForm.tsx
@@ -6,6 +6,8 @@ import { X } from 'lucide-react';
 import { addMonths } from 'date-fns';
 import { PatientFormFields } from './patient-form/PatientFormFields';
 import { PatientFormActions } from './patient-form/PatientFormActions';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { PatientAppointments } from '@/components/PatientAppointments';
 
 interface PatientFormProps {
   patient?: Patient;
@@ -93,19 +95,34 @@ export const PatientForm: React.FC<PatientFormProps> = ({ patient, onSave, onCan
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <PatientFormFields
-            formData={formData}
-            onChange={handleChange}
-            onPeriodChange={handlePeriodChange}
-          />
+        <Tabs defaultValue="dados" className="mt-4">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="dados">Dados</TabsTrigger>
+            <TabsTrigger value="consultas" disabled={!patient}>Consultas</TabsTrigger>
+          </TabsList>
 
-          <PatientFormActions
-            onCancel={onCancel}
-            isEditing={!!patient}
-            disabled={!isFormValid}
-          />
-        </form>
+          <TabsContent value="dados">
+            <form onSubmit={handleSubmit} className="space-y-4 mt-4">
+              <PatientFormFields
+                formData={formData}
+                onChange={handleChange}
+                onPeriodChange={handlePeriodChange}
+              />
+
+              <PatientFormActions
+                onCancel={onCancel}
+                isEditing={!!patient}
+                disabled={!isFormValid}
+              />
+            </form>
+          </TabsContent>
+
+          <TabsContent value="consultas">
+            {patient?.id && (
+              <PatientAppointments patientId={patient.id} />
+            )}
+          </TabsContent>
+        </Tabs>
       </DialogContent>
     </Dialog>
   );

--- a/src/hooks/usePatientAppointments.ts
+++ b/src/hooks/usePatientAppointments.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { Appointment } from '@/types/appointment';
+
+export const usePatientAppointments = (patientId?: string) => {
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!patientId) {
+      setAppointments([]);
+      return;
+    }
+
+    const fetchAppointments = async () => {
+      setLoading(true);
+      try {
+        const { data, error } = await supabase
+          .from('appointments')
+          .select('*, location:locations(name, address)')
+          .eq('patient_id', patientId)
+          .order('start_time', { ascending: false });
+        if (error) throw error;
+        setAppointments((data || []) as Appointment[]);
+      } catch (error) {
+        console.error('Error fetching patient appointments:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAppointments();
+  }, [patientId]);
+
+  return { appointments, loading };
+};


### PR DESCRIPTION
## Summary
- show patient consultations in new tab within patient form
- add hook to load appointments by patient

## Testing
- `npm run lint` *(fails: Unexpected any errors and forbidden require in tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_6898eb04f80883309005c1a826f27f95