### PR TITLE
Add WhatsApp appointment reminders

### DIFF
--- a/src/components/PatientAppointments.tsx
+++ b/src/components/PatientAppointments.tsx
@@ -1,16 +1,66 @@
 import React from 'react';
 import { usePatientAppointments } from '@/hooks/usePatientAppointments';
 import { Card, CardContent } from '@/components/ui/card';
-import { Calendar, Clock } from 'lucide-react';
+import { Calendar, Clock, MessageSquare } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+import { OrganizationSettings } from '@/types/organization';
+import { Patient } from '@/types/patient';
+import { Appointment } from '@/types/appointment';
 
 interface PatientAppointmentsProps {
   patientId: string;
+  patient: Patient;
+  organizationSettings?: OrganizationSettings | null;
 }
 
-export const PatientAppointments: React.FC<PatientAppointmentsProps> = ({ patientId }) => {
+export const PatientAppointments: React.FC<PatientAppointmentsProps> = ({
+  patientId,
+  patient,
+  organizationSettings,
+}) => {
   const { appointments, loading } = usePatientAppointments(patientId);
+  const navigate = useNavigate();
+
+  const formatMessage = (template: string, appointment: Appointment) => {
+    return template
+      .replace('{nome_do_paciente}', patient.name)
+      .replace(
+        '{data_consulta}',
+        format(new Date(appointment.start_time), 'dd/MM/yyyy', { locale: ptBR })
+      )
+      .replace(
+        '{hora_consulta}',
+        format(new Date(appointment.start_time), 'HH:mm', { locale: ptBR })
+      );
+  };
+
+  const handleWhatsApp = (
+    appointment: Appointment,
+    e: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    e.stopPropagation();
+    const defaultMessage =
+      organizationSettings?.whatsapp_appointment_message ||
+      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}.';
+    const message = formatMessage(defaultMessage, appointment);
+    const phone = patient.phone;
+    const url = `https://wa.me/55${phone.replace(/\D/g, '')}?text=${encodeURIComponent(
+      message
+    )}`;
+    window.open(url, '_blank');
+  };
+
+  const handleCardClick = (appointment: Appointment) => {
+    const dateParam = format(
+      new Date(appointment.start_time),
+      'yyyy-MM-dd'
+    );
+    const hourParam = format(new Date(appointment.start_time), 'HH');
+    navigate(`/appointments?date=${dateParam}&hour=${hourParam}`);
+  };
 
   if (loading) {
     return <p className="text-sm text-dental-secondary p-4">Carregando...</p>;
@@ -22,22 +72,50 @@ export const PatientAppointments: React.FC<PatientAppointmentsProps> = ({ patien
 
   return (
     <div className="space-y-3 p-1">
-      {appointments.map(appointment => (
-        <Card key={appointment.id}>
-          <CardContent className="p-3">
-            <div className="font-medium text-dental-primary">{appointment.title}</div>
-            <div className="flex items-center gap-2 text-sm text-dental-secondary mt-1">
-              <Calendar className="w-4 h-4" />
-              <span>{format(new Date(appointment.start_time), 'dd/MM/yyyy', { locale: ptBR })}</span>
-              <Clock className="w-4 h-4 ml-2" />
-              <span>
-                {format(new Date(appointment.start_time), 'HH:mm', { locale: ptBR })} -
-                {format(new Date(appointment.end_time), 'HH:mm', { locale: ptBR })}
-              </span>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
+      {appointments.map((appointment) => {
+        const isFuture = new Date(appointment.start_time) > new Date();
+        return (
+          <Card
+            key={appointment.id}
+            onClick={() => handleCardClick(appointment)}
+            className="cursor-pointer"
+          >
+            <CardContent className="p-3 flex items-center justify-between">
+              <div>
+                <div className="font-medium text-dental-primary">{appointment.title}</div>
+                <div className="flex items-center gap-2 text-sm text-dental-secondary mt-1">
+                  <Calendar className="w-4 h-4" />
+                  <span>
+                    {format(new Date(appointment.start_time), 'dd/MM/yyyy', {
+                      locale: ptBR,
+                    })}
+                  </span>
+                  <Clock className="w-4 h-4 ml-2" />
+                  <span>
+                    {format(new Date(appointment.start_time), 'HH:mm', {
+                      locale: ptBR,
+                    })}{' '}
+                    -
+                    {format(new Date(appointment.end_time), 'HH:mm', {
+                      locale: ptBR,
+                    })}
+                  </span>
+                </div>
+              </div>
+              {isFuture && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-green-500 text-green-600 hover:bg-green-50"
+                  onClick={(e) => handleWhatsApp(appointment, e)}
+                >
+                  <MessageSquare className="w-4 h-4" />
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/PatientForm.tsx
+++ b/src/components/PatientForm.tsx
@@ -8,14 +8,21 @@ import { PatientFormFields } from './patient-form/PatientFormFields';
 import { PatientFormActions } from './patient-form/PatientFormActions';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PatientAppointments } from '@/components/PatientAppointments';
+import { OrganizationSettings } from '@/types/organization';
 
 interface PatientFormProps {
   patient?: Patient;
+  organizationSettings?: OrganizationSettings | null;
   onSave: (patient: PatientCreateData) => void;
   onCancel: () => void;
 }
 
-export const PatientForm: React.FC<PatientFormProps> = ({ patient, onSave, onCancel }) => {
+export const PatientForm: React.FC<PatientFormProps> = ({
+  patient,
+  organizationSettings,
+  onSave,
+  onCancel,
+}) => {
   const [formData, setFormData] = useState<PatientCreateData>({
     name: '',
     phone: '',
@@ -119,7 +126,11 @@ export const PatientForm: React.FC<PatientFormProps> = ({ patient, onSave, onCan
 
           <TabsContent value="consultas">
             {patient?.id && (
-              <PatientAppointments patientId={patient.id} />
+              <PatientAppointments
+                patientId={patient.id}
+                patient={patient}
+                organizationSettings={organizationSettings}
+              />
             )}
           </TabsContent>
         </Tabs>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -18,7 +18,15 @@ interface SettingsModalProps {
   patients: Patient[];
   onUpdateProfile: (updates: { name: string }) => void;
   onUpdateSettings: (
-    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+    updates: Partial<
+      Pick<
+        OrganizationSettings,
+        | 'whatsapp_default_message'
+        | 'whatsapp_appointment_message'
+        | 'working_hours_start'
+        | 'working_hours_end'
+      >
+    >
   ) => void;
   onBulkImport: (patientsData: Omit<Patient, 'id' | 'contactHistory'>[], userId: string) => Promise<number>;
   onDeletePatient: (patientId: string) => void;

--- a/src/components/settings/SettingsModalContent.tsx
+++ b/src/components/settings/SettingsModalContent.tsx
@@ -17,7 +17,15 @@ interface SettingsModalContentProps {
   isAdmin: boolean;
   onUpdateProfile: (updates: { name: string }) => void;
   onUpdateSettings: (
-    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+    updates: Partial<
+      Pick<
+        OrganizationSettings,
+        | 'whatsapp_default_message'
+        | 'whatsapp_appointment_message'
+        | 'working_hours_start'
+        | 'working_hours_end'
+      >
+    >
   ) => void;
   onShowExcelImport: () => void;
   onShowPatientRemoval: () => void;

--- a/src/components/settings/WhatsAppTab.tsx
+++ b/src/components/settings/WhatsAppTab.tsx
@@ -9,7 +9,12 @@ import { UserProfile, OrganizationSettings } from '@/types/organization';
 interface WhatsAppTabProps {
   userProfile: UserProfile | null;
   organizationSettings: OrganizationSettings | null;
-  onUpdateSettings: (updates: { whatsapp_default_message: string }) => void;
+  onUpdateSettings: (
+    updates: {
+      whatsapp_default_message: string;
+      whatsapp_appointment_message: string;
+    }
+  ) => void;
 }
 
 export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
@@ -20,26 +25,35 @@ export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
   const [whatsappMessage, setWhatsappMessage] = useState(
     organizationSettings?.whatsapp_default_message || ''
   );
+  const [whatsappAppointmentMessage, setWhatsappAppointmentMessage] = useState(
+    organizationSettings?.whatsapp_appointment_message || ''
+  );
 
   useEffect(() => {
     setWhatsappMessage(organizationSettings?.whatsapp_default_message || '');
+    setWhatsappAppointmentMessage(
+      organizationSettings?.whatsapp_appointment_message || ''
+    );
   }, [organizationSettings]);
 
   const handleSaveWhatsappMessage = () => {
-    onUpdateSettings({ whatsapp_default_message: whatsappMessage });
+    onUpdateSettings({
+      whatsapp_default_message: whatsappMessage,
+      whatsapp_appointment_message: whatsappAppointmentMessage,
+    });
   };
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-dental-primary">Mensagem Padrão WhatsApp</CardTitle>
+        <CardTitle className="text-dental-primary">Mensagens Padrão WhatsApp</CardTitle>
         <CardDescription>
-          Configure a mensagem enviada aos pacientes
+          Configure as mensagens enviadas aos pacientes
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div>
-          <Label htmlFor="whatsappMessage">Mensagem</Label>
+          <Label htmlFor="whatsappMessage">Mensagem de Retomada</Label>
           <Textarea
             id="whatsappMessage"
             value={whatsappMessage}
@@ -52,11 +66,31 @@ export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
             Variáveis disponíveis: {'{nome_do_paciente}'}, {'{data_proximo_contato}'}
           </p>
         </div>
+        <div>
+          <Label htmlFor="whatsappAppointmentMessage">Mensagem de Lembrete de Consulta</Label>
+          <Textarea
+            id="whatsappAppointmentMessage"
+            value={whatsappAppointmentMessage}
+            onChange={(e) => setWhatsappAppointmentMessage(e.target.value)}
+            placeholder="Digite a mensagem de lembrete..."
+            rows={4}
+            disabled={userProfile?.role !== 'admin'}
+          />
+          <p className="text-xs text-dental-secondary mt-2">
+            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{data_consulta}'}, {'{hora_consulta}'}
+          </p>
+        </div>
         {userProfile?.role === 'admin' && (
-          <Button 
+          <Button
             onClick={handleSaveWhatsappMessage}
             className="bg-dental-primary hover:bg-dental-secondary"
-            disabled={!whatsappMessage.trim() || whatsappMessage === organizationSettings?.whatsapp_default_message}
+            disabled={
+              !whatsappMessage.trim() ||
+              !whatsappAppointmentMessage.trim() ||
+              (whatsappMessage === organizationSettings?.whatsapp_default_message &&
+                whatsappAppointmentMessage ===
+                  organizationSettings?.whatsapp_appointment_message)
+            }
           >
             Salvar Mensagem
           </Button>

--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -174,7 +174,15 @@ export const useOrganization = (user: User | null) => {
   };
 
   const updateOrganizationSettings = async (
-    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+    updates: Partial<
+      Pick<
+        OrganizationSettings,
+        | 'whatsapp_default_message'
+        | 'whatsapp_appointment_message'
+        | 'working_hours_start'
+        | 'working_hours_end'
+      >
+    >
   ) => {
     if (!userProfile?.organization_id) return;
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -210,6 +210,7 @@ export type Database = {
           organization_id: string
           updated_at: string
           whatsapp_default_message: string | null
+          whatsapp_appointment_message: string | null
           working_hours_end: number | null
           working_hours_start: number | null
         }
@@ -219,6 +220,7 @@ export type Database = {
           organization_id: string
           updated_at?: string
           whatsapp_default_message?: string | null
+          whatsapp_appointment_message?: string | null
           working_hours_end?: number | null
           working_hours_start?: number | null
         }
@@ -228,6 +230,7 @@ export type Database = {
           organization_id?: string
           updated_at?: string
           whatsapp_default_message?: string | null
+          whatsapp_appointment_message?: string | null
           working_hours_end?: number | null
           working_hours_start?: number | null
         }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -385,6 +385,7 @@ const Index = () => {
             {showPatientForm && (
               <PatientForm
                 patient={editingPatient}
+                organizationSettings={organizationSettings}
                 onSave={editingPatient ? handleUpdatePatient : handleAddPatient}
                 onCancel={() => {
                   setShowPatientForm(false);

--- a/src/services/organizationSettingsService.ts
+++ b/src/services/organizationSettingsService.ts
@@ -28,11 +28,21 @@ export class OrganizationSettingsService {
 
   static async updateOrganizationSettings(
     organizationId: string,
-    updates: Partial<Pick<OrganizationSettings, 'whatsapp_default_message' | 'working_hours_start' | 'working_hours_end'>>
+    updates: Partial<
+      Pick<
+        OrganizationSettings,
+        | 'whatsapp_default_message'
+        | 'whatsapp_appointment_message'
+        | 'working_hours_start'
+        | 'working_hours_end'
+      >
+    >
   ): Promise<void> {
     console.log('📝 OrganizationSettingsService.updateOrganizationSettings:', { organizationId, updates });
     const defaultMessage =
       'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!';
+    const defaultAppointmentMessage =
+      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}. Até breve!';
 
     const { data: existing, error: fetchError } = await supabase
       .from('organization_settings')
@@ -49,6 +59,10 @@ export class OrganizationSettingsService {
       organization_id: organizationId,
       whatsapp_default_message:
         updates.whatsapp_default_message ?? existing?.whatsapp_default_message ?? defaultMessage,
+      whatsapp_appointment_message:
+        updates.whatsapp_appointment_message ??
+        existing?.whatsapp_appointment_message ??
+        defaultAppointmentMessage,
       working_hours_start: updates.working_hours_start ?? existing?.working_hours_start ?? 8,
       working_hours_end: updates.working_hours_end ?? existing?.working_hours_end ?? 18,
     };
@@ -68,7 +82,7 @@ export class OrganizationSettingsService {
 
   static async createDefaultSettings(organizationId: string): Promise<void> {
     console.log('⚙️ OrganizationSettingsService.createDefaultSettings:', organizationId);
-    
+
     const { error } = await supabase
       .from('organization_settings')
       .insert([
@@ -76,6 +90,8 @@ export class OrganizationSettingsService {
           organization_id: organizationId,
           whatsapp_default_message:
             'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!',
+          whatsapp_appointment_message:
+            'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}. Até breve!',
           working_hours_start: 8,
           working_hours_end: 18,
         },

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -22,6 +22,7 @@ export interface OrganizationSettings {
   id: string;
   organization_id: string;
   whatsapp_default_message: string;
+  whatsapp_appointment_message: string;
   working_hours_start: number | null;
   working_hours_end: number | null;
   created_at: string;

--- a/supabase/migrations/20250901000000-add-whatsapp-appointment-message.sql
+++ b/supabase/migrations/20250901000000-add-whatsapp-appointment-message.sql
@@ -1,0 +1,2 @@
+alter table organization_settings
+add column whatsapp_appointment_message text;


### PR DESCRIPTION
## Summary
- allow configuring separate WhatsApp templates for follow-up and appointment reminders
- send reminder message from patient and appointment screens
- support opening schedule on specific date via query parameters

## Testing
- `npm run lint` *(fails: Unexpected any in various files)*

------
https://chatgpt.com/codex/tasks/task_e_6898fbcea88c8330b9b8a811635870d6