### PR TITLE
feat: add global message variables for WhatsApp

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -45,6 +45,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import { OrganizationSettings } from '@/types/organization';
 import { ptBR } from 'date-fns/locale';
+import { formatMessage } from '@/utils/messageTemplates';
 
 const appointmentSchema = z
   .object({
@@ -276,16 +277,10 @@ export function AppointmentModal({
     const template =
       organizationSettings?.whatsapp_appointment_message ||
       'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}.';
-    const message = template
-      .replace('{nome_do_paciente}', appointment.patient.name)
-      .replace(
-        '{data_consulta}',
-        format(new Date(appointment.start_time), 'dd/MM/yyyy', { locale: ptBR })
-      )
-      .replace(
-        '{hora_consulta}',
-        format(new Date(appointment.start_time), 'HH:mm', { locale: ptBR })
-      );
+    const message = formatMessage(template, {
+      patient: appointment.patient,
+      appointment,
+    });
     const url = `https://wa.me/55${appointment.patient.phone.replace(/\D/g, '')}?text=${encodeURIComponent(
       message
     )}`;

--- a/src/components/PatientAppointments.tsx
+++ b/src/components/PatientAppointments.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Calendar, Clock, MessageSquare } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { formatMessage } from '@/utils/messageTemplates';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import { OrganizationSettings } from '@/types/organization';
@@ -24,19 +25,6 @@ export const PatientAppointments: React.FC<PatientAppointmentsProps> = ({
   const { appointments, loading } = usePatientAppointments(patientId);
   const navigate = useNavigate();
 
-  const formatMessage = (template: string, appointment: Appointment) => {
-    return template
-      .replace('{nome_do_paciente}', patient.name)
-      .replace(
-        '{data_consulta}',
-        format(new Date(appointment.start_time), 'dd/MM/yyyy', { locale: ptBR })
-      )
-      .replace(
-        '{hora_consulta}',
-        format(new Date(appointment.start_time), 'HH:mm', { locale: ptBR })
-      );
-  };
-
   const handleWhatsApp = (
     appointment: Appointment,
     e: React.MouseEvent<HTMLButtonElement>
@@ -45,7 +33,7 @@ export const PatientAppointments: React.FC<PatientAppointmentsProps> = ({
     const defaultMessage =
       organizationSettings?.whatsapp_appointment_message ||
       'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}.';
-    const message = formatMessage(defaultMessage, appointment);
+    const message = formatMessage(defaultMessage, { patient, appointment });
     const phone = patient.phone;
     const url = `https://wa.me/55${phone.replace(/\D/g, '')}?text=${encodeURIComponent(
       message

--- a/src/components/PatientCard.tsx
+++ b/src/components/PatientCard.tsx
@@ -10,6 +10,7 @@ import { ContactHistoryModal } from '@/components/ContactHistoryModal';
 import { Phone, MessageSquare, Calendar, Edit, Clock, AlertTriangle, User, History, ChevronDown } from 'lucide-react';
 import { format, isBefore, isAfter, startOfToday, addDays } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { formatMessage } from '@/utils/messageTemplates';
 
 interface PatientCardProps {
   patient: Patient;
@@ -42,22 +43,11 @@ export const PatientCard: React.FC<PatientCardProps> = ({
     return <Calendar className="w-4 h-4 text-dental-primary" />;
   };
 
-  const formatWhatsAppMessage = (message: string) => {
-    const firstName = patient.name.split(' ')[0];
-    const lastVisitFormatted = format(patient.lastVisit, 'dd/MM/yyyy', { locale: ptBR });
-    
-    return message
-      .replace('{nome_do_paciente}', patient.name)
-      .replace('{primeiro_nome_do_paciente}', firstName)
-      .replace('{data_proximo_contato}', format(patient.nextContactDate, 'dd/MM/yyyy', { locale: ptBR }))
-      .replace('{data_ultima_consulta}', lastVisitFormatted);
-  };
-
   const handleWhatsAppClick = (phoneNumber: string) => {
-    const defaultMessage = organizationSettings?.whatsapp_default_message || 
+    const defaultMessage = organizationSettings?.whatsapp_default_message ||
       'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!';
-    
-    const message = formatWhatsAppMessage(defaultMessage);
+
+    const message = formatMessage(defaultMessage, { patient });
     const whatsappUrl = `https://wa.me/55${phoneNumber.replace(/\D/g, '')}?text=${encodeURIComponent(message)}`;
     window.open(whatsappUrl, '_blank');
   };

--- a/src/components/settings/WhatsAppTab.tsx
+++ b/src/components/settings/WhatsAppTab.tsx
@@ -63,7 +63,7 @@ export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
             disabled={userProfile?.role !== 'admin'}
           />
           <p className="text-xs text-dental-secondary mt-2">
-            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{data_proximo_contato}'}
+            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{primeiro_nome_do_paciente}'}, {'{data_proximo_contato}'}
           </p>
         </div>
         <div>
@@ -77,7 +77,7 @@ export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
             disabled={userProfile?.role !== 'admin'}
           />
           <p className="text-xs text-dental-secondary mt-2">
-            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{data_consulta}'}, {'{hora_consulta}'}
+            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{primeiro_nome_do_paciente}'}, {'{data_consulta}'}, {'{hora_consulta}'}
           </p>
         </div>
         {userProfile?.role === 'admin' && (

--- a/src/utils/messageTemplates.ts
+++ b/src/utils/messageTemplates.ts
@@ -1,0 +1,49 @@
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { Appointment } from '@/types/appointment';
+
+interface PatientInfo {
+  name: string;
+  lastVisit?: Date;
+  nextContactDate?: Date;
+}
+
+interface MessageTemplateData {
+  patient: PatientInfo;
+  appointment?: Appointment;
+}
+
+export function formatMessage(template: string, { patient, appointment }: MessageTemplateData): string {
+  const firstName = patient.name.split(' ')[0];
+  let message = template
+    .replace('{nome_do_paciente}', patient.name)
+    .replace('{primeiro_nome_do_paciente}', firstName);
+
+  if (patient.nextContactDate) {
+    message = message.replace(
+      '{data_proximo_contato}',
+      format(patient.nextContactDate, 'dd/MM/yyyy', { locale: ptBR })
+    );
+  }
+
+  if (patient.lastVisit) {
+    message = message.replace(
+      '{data_ultima_consulta}',
+      format(patient.lastVisit, 'dd/MM/yyyy', { locale: ptBR })
+    );
+  }
+
+  if (appointment) {
+    message = message
+      .replace(
+        '{data_consulta}',
+        format(new Date(appointment.start_time), 'dd/MM/yyyy', { locale: ptBR })
+      )
+      .replace(
+        '{hora_consulta}',
+        format(new Date(appointment.start_time), 'HH:mm', { locale: ptBR })
+      );
+  }
+
+  return message;
+}


### PR DESCRIPTION
## Summary
- centralize placeholder replacements in new message formatter
- use shared formatter for WhatsApp reminders and appointments
- document first-name placeholder in settings

## Testing
- `npm run lint` *(fails: Unexpected any, require import in unrelated files)*
- `npx eslint src/utils/messageTemplates.ts src/components/PatientCard.tsx src/components/PatientAppointments.tsx src/components/AppointmentModal.tsx src/components/settings/WhatsAppTab.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68990153bbe88330b3ab453bc8ee7bdb