### PR TITLE
refactor: use icon-only whatsapp button

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -706,8 +706,8 @@ export function AppointmentModal({
                     className="border-green-500 text-green-600 hover:bg-green-50"
                     onClick={handleSendWhatsApp}
                   >
-                    <MessageSquare className="w-4 h-4 mr-1" />
-                    WhatsApp
+                    <MessageSquare className="w-4 h-4" />
+                    <span className="sr-only">WhatsApp</span>
                   </Button>
                 )}
                 <Button type="button" variant="outline" onClick={onClose}>


### PR DESCRIPTION
## Summary
- replace whatsapp text label with icon-only button

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68990401b4b483308a6b972050d88943