### PR TITLE
Align time column width with header

### DIFF
--- a/src/components/schedule/WeekSchedule.tsx
+++ b/src/components/schedule/WeekSchedule.tsx
@@ -23,6 +23,7 @@ interface WeekScheduleProps {
   firstHourRef: RefObject<HTMLDivElement>;
   scrollTargetHour?: number;
   showNonWorkingHours?: boolean;
+  timeColumnWidth?: string;
 }
 
 // Visual constants
@@ -110,6 +111,7 @@ export function WeekSchedule(props: WeekScheduleProps) {
     firstHourRef,
     scrollTargetHour = 8,
     showNonWorkingHours = false,
+    timeColumnWidth = '3rem',
   } = props;
 
   const hours = useMemo(() => Array.from({ length: TOTAL_HOURS }, (_, i) => i), []);
@@ -161,7 +163,7 @@ export function WeekSchedule(props: WeekScheduleProps) {
     <div ref={scheduleRef} className="h-full overflow-y-auto border border-t-0 rounded-b-lg">
       <div
         className="grid gap-0"
-        style={{ gridTemplateColumns: `auto repeat(${daysToDisplay.length}, 1fr)` }}
+        style={{ gridTemplateColumns: `${timeColumnWidth} repeat(${daysToDisplay.length}, 1fr)` }}
       >
         {/* Time column */}
         <div className="border-r">

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -82,6 +82,7 @@ export default function Appointments() {
   const [searchParams] = useSearchParams();
   const scheduleRef = useRef<HTMLDivElement>(null);
   const firstHourRef = useRef<HTMLDivElement>(null);
+  const timeColumnWidth = '3rem';
 
   useEffect(() => {
     const dateParam = searchParams.get('date');
@@ -247,7 +248,7 @@ export default function Appointments() {
           {/* Header with days */}
           <div
             className="grid gap-0 border rounded-t-lg overflow-hidden"
-            style={{ gridTemplateColumns: `auto repeat(${daysToDisplay.length}, 1fr)` }}
+            style={{ gridTemplateColumns: `${timeColumnWidth} repeat(${daysToDisplay.length}, 1fr)` }}
           >
             <div className="bg-muted p-2 border-r text-center">
               <Button
@@ -290,6 +291,7 @@ export default function Appointments() {
             firstHourRef={firstHourRef}
             scrollTargetHour={scrollTargetHour}
             showNonWorkingHours={showNonWorkingHours}
+            timeColumnWidth={timeColumnWidth}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- fix schedule header and time column width by introducing shared `timeColumnWidth`
- plumb `timeColumnWidth` through `WeekSchedule` for consistent layout

## Testing
- `npm run lint` *(fails: Unexpected any, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689a5b003c6c8330bb024d7eed0326ca