### PR TITLE
feat: support default location and title

### DIFF
--- a/src/hooks/useAppointments.ts
+++ b/src/hooks/useAppointments.ts
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
-import { Appointment, Location, AppointmentFormData } from '@/types/appointment';
+import { Appointment, Location, AppointmentFormData, AppointmentTitle } from '@/types/appointment';
 import { useAuth } from './useAuth';
 import { useOrganization } from './useOrganization';
 
 export const useAppointments = () => {
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [locations, setLocations] = useState<Location[]>([]);
-  const [titles, setTitles] = useState<string[]>([]);
+  const [titles, setTitles] = useState<AppointmentTitle[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
   const { user } = useAuth();
@@ -68,13 +68,13 @@ export const useAppointments = () => {
     try {
       const { data, error } = await supabase
         .from('appointment_titles')
-        .select('title')
+        .select('id, title, is_default, is_active')
         .eq('organization_id', userProfile.organization_id)
         .eq('is_active', true)
         .order('title');
 
       if (error) throw error;
-      setTitles((data || []).map((t: { title: string }) => t.title));
+      setTitles((data || []) as AppointmentTitle[]);
     } catch (error) {
       console.error('Error fetching titles:', error);
       toast({
@@ -141,7 +141,7 @@ export const useAppointments = () => {
     }
 
     try {
-      const updateData: any = { ...appointmentData };
+      const updateData: Record<string, unknown> = { ...appointmentData };
       if (appointmentData.start_time) {
         updateData.start_time = appointmentData.start_time.toISOString();
       }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -171,6 +171,7 @@ export type Database = {
           created_at: string
           id: string
           is_active: boolean
+          is_default: boolean
           name: string
           organization_id: string
           updated_at: string
@@ -180,6 +181,7 @@ export type Database = {
           created_at?: string
           id?: string
           is_active?: boolean
+          is_default?: boolean
           name: string
           organization_id: string
           updated_at?: string
@@ -189,6 +191,7 @@ export type Database = {
           created_at?: string
           id?: string
           is_active?: boolean
+          is_default?: boolean
           name?: string
           organization_id?: string
           updated_at?: string

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -4,6 +4,7 @@ export interface Location {
   name: string;
   address?: string;
   is_active: boolean;
+  is_default: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20250906090000-add-default-location.sql
+++ b/supabase/migrations/20250906090000-add-default-location.sql
@@ -1,0 +1,63 @@
+-- Add default flag to locations and ensure single default per organization
+ALTER TABLE public.locations
+ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT false;
+
+-- Create or replace validation function for locations
+CREATE OR REPLACE FUNCTION public.validate_locations()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Ensure there is always at least one active location
+  IF TG_OP = 'UPDATE' AND NEW.is_active = false AND OLD.is_active = true THEN
+    IF (SELECT COUNT(*) FROM public.locations
+        WHERE organization_id = NEW.organization_id
+          AND is_active = true
+          AND id <> NEW.id) = 0 THEN
+      RAISE EXCEPTION 'Deve haver pelo menos um local ativo';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'DELETE' AND OLD.is_active = true THEN
+    IF (SELECT COUNT(*) FROM public.locations
+        WHERE organization_id = OLD.organization_id
+          AND is_active = true
+          AND id <> OLD.id) = 0 THEN
+      RAISE EXCEPTION 'Deve haver pelo menos um local ativo';
+    END IF;
+  END IF;
+
+  -- Handle default location logic
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    IF NEW.is_default = true THEN
+      UPDATE public.locations
+      SET is_default = false
+      WHERE organization_id = NEW.organization_id
+        AND id <> NEW.id;
+    END IF;
+
+    IF NEW.is_active = true THEN
+      IF (SELECT COUNT(*) FROM public.locations
+            WHERE organization_id = NEW.organization_id
+              AND is_active = true
+              AND is_default = true) = 0 THEN
+        NEW.is_default = true;
+      END IF;
+    END IF;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Replace existing trigger
+DROP TRIGGER IF EXISTS validate_active_locations_trigger ON public.locations;
+CREATE TRIGGER validate_locations_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON public.locations
+FOR EACH ROW
+EXECUTE FUNCTION public.validate_locations();
+
+-- Drop old validation function if it exists
+DROP FUNCTION IF EXISTS public.validate_active_locations();


### PR DESCRIPTION
## Summary
- allow marking a location as the default and show badge/button in settings
- load default title and location when scheduling new appointments
- add database migration to track and validate default locations

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx eslint src/components/AppointmentModal.tsx src/components/settings/LocationsTab.tsx src/hooks/useAppointments.ts src/integrations/supabase/types.ts src/types/appointment.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a5bea47208330923be984aad37ccb