### PR TITLE
feat: add birthday WhatsApp reminder

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -23,6 +23,7 @@ interface SettingsModalProps {
         OrganizationSettings,
         | 'whatsapp_default_message'
         | 'whatsapp_appointment_message'
+        | 'whatsapp_birthday_message'
         | 'working_hours_start'
         | 'working_hours_end'
       >

--- a/src/components/settings/SettingsModalContent.tsx
+++ b/src/components/settings/SettingsModalContent.tsx
@@ -22,6 +22,7 @@ interface SettingsModalContentProps {
         OrganizationSettings,
         | 'whatsapp_default_message'
         | 'whatsapp_appointment_message'
+        | 'whatsapp_birthday_message'
         | 'working_hours_start'
         | 'working_hours_end'
       >

--- a/src/components/settings/WhatsAppTab.tsx
+++ b/src/components/settings/WhatsAppTab.tsx
@@ -4,16 +4,21 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
+import { Pencil, X, Check } from 'lucide-react';
 import { UserProfile, OrganizationSettings } from '@/types/organization';
 
 interface WhatsAppTabProps {
   userProfile: UserProfile | null;
   organizationSettings: OrganizationSettings | null;
   onUpdateSettings: (
-    updates: {
-      whatsapp_default_message: string;
-      whatsapp_appointment_message: string;
-    }
+    updates: Partial<
+      Pick<
+        OrganizationSettings,
+        | 'whatsapp_default_message'
+        | 'whatsapp_appointment_message'
+        | 'whatsapp_birthday_message'
+      >
+    >
   ) => void;
 }
 
@@ -28,19 +33,37 @@ export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
   const [whatsappAppointmentMessage, setWhatsappAppointmentMessage] = useState(
     organizationSettings?.whatsapp_appointment_message || ''
   );
+  const [whatsappBirthdayMessage, setWhatsappBirthdayMessage] = useState(
+    organizationSettings?.whatsapp_birthday_message || ''
+  );
+
+  const [editDefault, setEditDefault] = useState(false);
+  const [editAppointment, setEditAppointment] = useState(false);
+  const [editBirthday, setEditBirthday] = useState(false);
 
   useEffect(() => {
     setWhatsappMessage(organizationSettings?.whatsapp_default_message || '');
     setWhatsappAppointmentMessage(
       organizationSettings?.whatsapp_appointment_message || ''
     );
+    setWhatsappBirthdayMessage(
+      organizationSettings?.whatsapp_birthday_message || ''
+    );
   }, [organizationSettings]);
 
-  const handleSaveWhatsappMessage = () => {
-    onUpdateSettings({
-      whatsapp_default_message: whatsappMessage,
-      whatsapp_appointment_message: whatsappAppointmentMessage,
-    });
+  const handleSaveDefault = () => {
+    onUpdateSettings({ whatsapp_default_message: whatsappMessage });
+    setEditDefault(false);
+  };
+
+  const handleSaveAppointment = () => {
+    onUpdateSettings({ whatsapp_appointment_message: whatsappAppointmentMessage });
+    setEditAppointment(false);
+  };
+
+  const handleSaveBirthday = () => {
+    onUpdateSettings({ whatsapp_birthday_message: whatsappBirthdayMessage });
+    setEditBirthday(false);
   };
 
   return (
@@ -51,53 +74,127 @@ export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
           Configure as mensagens enviadas aos pacientes
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-6">
         <div>
-          <Label htmlFor="whatsappMessage">Mensagem de Retomada</Label>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="whatsappMessage">Mensagem de Retomada</Label>
+            {userProfile?.role === 'admin' && !editDefault && (
+              <Button variant="ghost" size="icon" onClick={() => setEditDefault(true)}>
+                <Pencil className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
           <Textarea
             id="whatsappMessage"
             value={whatsappMessage}
             onChange={(e) => setWhatsappMessage(e.target.value)}
             placeholder="Digite sua mensagem padrão..."
             rows={4}
-            disabled={userProfile?.role !== 'admin'}
+            disabled={!editDefault}
           />
           <p className="text-xs text-dental-secondary mt-2">
             Variáveis disponíveis: {'{nome_do_paciente}'}, {'{primeiro_nome_do_paciente}'}, {'{data_proximo_contato}'}
           </p>
+          {editDefault && (
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" onClick={handleSaveDefault} disabled={!whatsappMessage.trim()}>
+                <Check className="w-4 h-4 mr-1" /> Salvar
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setWhatsappMessage(organizationSettings?.whatsapp_default_message || '');
+                  setEditDefault(false);
+                }}
+              >
+                <X className="w-4 h-4 mr-1" /> Cancelar
+              </Button>
+            </div>
+          )}
         </div>
+
         <div>
-          <Label htmlFor="whatsappAppointmentMessage">Mensagem de Lembrete de Consulta</Label>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="whatsappAppointmentMessage">Mensagem de Lembrete de Consulta</Label>
+            {userProfile?.role === 'admin' && !editAppointment && (
+              <Button variant="ghost" size="icon" onClick={() => setEditAppointment(true)}>
+                <Pencil className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
           <Textarea
             id="whatsappAppointmentMessage"
             value={whatsappAppointmentMessage}
             onChange={(e) => setWhatsappAppointmentMessage(e.target.value)}
             placeholder="Digite a mensagem de lembrete..."
             rows={4}
-            disabled={userProfile?.role !== 'admin'}
+            disabled={!editAppointment}
           />
           <p className="text-xs text-dental-secondary mt-2">
             Variáveis disponíveis: {'{nome_do_paciente}'}, {'{primeiro_nome_do_paciente}'}, {'{data_consulta}'}, {'{hora_consulta}'}
           </p>
+          {editAppointment && (
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" onClick={handleSaveAppointment} disabled={!whatsappAppointmentMessage.trim()}>
+                <Check className="w-4 h-4 mr-1" /> Salvar
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setWhatsappAppointmentMessage(organizationSettings?.whatsapp_appointment_message || '');
+                  setEditAppointment(false);
+                }}
+              >
+                <X className="w-4 h-4 mr-1" /> Cancelar
+              </Button>
+            </div>
+          )}
         </div>
-        {userProfile?.role === 'admin' && (
-          <Button
-            onClick={handleSaveWhatsappMessage}
-            className="bg-dental-primary hover:bg-dental-secondary"
-            disabled={
-              !whatsappMessage.trim() ||
-              !whatsappAppointmentMessage.trim() ||
-              (whatsappMessage === organizationSettings?.whatsapp_default_message &&
-                whatsappAppointmentMessage ===
-                  organizationSettings?.whatsapp_appointment_message)
-            }
-          >
-            Salvar Mensagem
-          </Button>
-        )}
+
+        <div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="whatsappBirthdayMessage">Mensagem de Lembrete de Aniversário</Label>
+            {userProfile?.role === 'admin' && !editBirthday && (
+              <Button variant="ghost" size="icon" onClick={() => setEditBirthday(true)}>
+                <Pencil className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
+          <Textarea
+            id="whatsappBirthdayMessage"
+            value={whatsappBirthdayMessage}
+            onChange={(e) => setWhatsappBirthdayMessage(e.target.value)}
+            placeholder="Digite a mensagem de aniversário..."
+            rows={4}
+            disabled={!editBirthday}
+          />
+          <p className="text-xs text-dental-secondary mt-2">
+            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{primeiro_nome_do_paciente}'}, {'{data_aniversario}'}
+          </p>
+          {editBirthday && (
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" onClick={handleSaveBirthday} disabled={!whatsappBirthdayMessage.trim()}>
+                <Check className="w-4 h-4 mr-1" /> Salvar
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setWhatsappBirthdayMessage(organizationSettings?.whatsapp_birthday_message || '');
+                  setEditBirthday(false);
+                }}
+              >
+                <X className="w-4 h-4 mr-1" /> Cancelar
+              </Button>
+            </div>
+          )}
+        </div>
+
         {userProfile?.role !== 'admin' && (
           <p className="text-sm text-amber-600">
-            Apenas administradores podem editar a mensagem padrão.
+            Apenas administradores podem editar as mensagens padrão.
           </p>
         )}
       </CardContent>

--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -179,6 +179,7 @@ export const useOrganization = (user: User | null) => {
         OrganizationSettings,
         | 'whatsapp_default_message'
         | 'whatsapp_appointment_message'
+        | 'whatsapp_birthday_message'
         | 'working_hours_start'
         | 'working_hours_end'
       >

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -210,33 +210,36 @@ export type Database = {
         Row: {
           created_at: string
           id: string
-          organization_id: string
-          updated_at: string
-          whatsapp_default_message: string | null
-          whatsapp_appointment_message: string | null
-          working_hours_end: number | null
-          working_hours_start: number | null
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          organization_id: string
-          updated_at?: string
-          whatsapp_default_message?: string | null
-          whatsapp_appointment_message?: string | null
-          working_hours_end?: number | null
-          working_hours_start?: number | null
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          organization_id?: string
-          updated_at?: string
-          whatsapp_default_message?: string | null
-          whatsapp_appointment_message?: string | null
-          working_hours_end?: number | null
-          working_hours_start?: number | null
-        }
+      organization_id: string
+      updated_at: string
+      whatsapp_default_message: string | null
+      whatsapp_appointment_message: string | null
+      whatsapp_birthday_message: string | null
+      working_hours_end: number | null
+      working_hours_start: number | null
+    }
+    Insert: {
+      created_at?: string
+      id?: string
+      organization_id: string
+      updated_at?: string
+      whatsapp_default_message?: string | null
+      whatsapp_appointment_message?: string | null
+      whatsapp_birthday_message?: string | null
+      working_hours_end?: number | null
+      working_hours_start?: number | null
+    }
+    Update: {
+      created_at?: string
+      id?: string
+      organization_id?: string
+      updated_at?: string
+      whatsapp_default_message?: string | null
+      whatsapp_appointment_message?: string | null
+      whatsapp_birthday_message?: string | null
+      working_hours_end?: number | null
+      working_hours_start?: number | null
+    }
         Relationships: [
           {
             foreignKeyName: "organization_settings_organization_id_fkey"

--- a/src/pages/Reminders.tsx
+++ b/src/pages/Reminders.tsx
@@ -148,6 +148,11 @@ const Reminders: React.FC = () => {
         organizationSettings?.whatsapp_appointment_message || '',
         { patient: { name: reminder.patient.name }, appointment: reminder.appointment }
       );
+    } else if (reminder.type === 'birthday') {
+      message = formatMessage(
+        organizationSettings?.whatsapp_birthday_message || '',
+        { patient: { name: reminder.patient.name, birthday: reminder.date } }
+      );
     } else if (reminder.type === 'contact') {
       message = formatMessage(
         organizationSettings?.whatsapp_default_message || '',

--- a/src/services/organizationSettingsService.ts
+++ b/src/services/organizationSettingsService.ts
@@ -33,6 +33,7 @@ export class OrganizationSettingsService {
         OrganizationSettings,
         | 'whatsapp_default_message'
         | 'whatsapp_appointment_message'
+        | 'whatsapp_birthday_message'
         | 'working_hours_start'
         | 'working_hours_end'
       >
@@ -43,6 +44,8 @@ export class OrganizationSettingsService {
       'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!';
     const defaultAppointmentMessage =
       'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}. Até breve!';
+    const defaultBirthdayMessage =
+      'Olá {nome_do_paciente}! Feliz aniversário! Desejamos um dia cheio de sorrisos!';
 
     const { data: existing, error: fetchError } = await supabase
       .from('organization_settings')
@@ -63,6 +66,10 @@ export class OrganizationSettingsService {
         updates.whatsapp_appointment_message ??
         existing?.whatsapp_appointment_message ??
         defaultAppointmentMessage,
+      whatsapp_birthday_message:
+        updates.whatsapp_birthday_message ??
+        existing?.whatsapp_birthday_message ??
+        defaultBirthdayMessage,
       working_hours_start: updates.working_hours_start ?? existing?.working_hours_start ?? 8,
       working_hours_end: updates.working_hours_end ?? existing?.working_hours_end ?? 18,
     };
@@ -92,6 +99,8 @@ export class OrganizationSettingsService {
             'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!',
           whatsapp_appointment_message:
             'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}. Até breve!',
+          whatsapp_birthday_message:
+            'Olá {nome_do_paciente}! Feliz aniversário! Desejamos um dia cheio de sorrisos!',
           working_hours_start: 8,
           working_hours_end: 18,
         },

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -23,6 +23,7 @@ export interface OrganizationSettings {
   organization_id: string;
   whatsapp_default_message: string;
   whatsapp_appointment_message: string;
+  whatsapp_birthday_message: string;
   working_hours_start: number | null;
   working_hours_end: number | null;
   created_at: string;

--- a/src/utils/messageTemplates.ts
+++ b/src/utils/messageTemplates.ts
@@ -6,6 +6,7 @@ interface PatientInfo {
   name: string;
   lastVisit?: Date;
   nextContactDate?: Date;
+  birthday?: Date;
 }
 
 interface MessageTemplateData {
@@ -23,6 +24,13 @@ export function formatMessage(template: string, { patient, appointment }: Messag
     message = message.replace(
       '{data_proximo_contato}',
       format(patient.nextContactDate, 'dd/MM/yyyy', { locale: ptBR })
+    );
+  }
+
+  if (patient.birthday) {
+    message = message.replace(
+      '{data_aniversario}',
+      format(patient.birthday, 'dd/MM/yyyy', { locale: ptBR })
     );
   }
 

--- a/supabase/migrations/20250907000000-add-whatsapp-birthday-message.sql
+++ b/supabase/migrations/20250907000000-add-whatsapp-birthday-message.sql
@@ -1,0 +1,2 @@
+alter table organization_settings
+add column whatsapp_birthday_message text;


### PR DESCRIPTION
## Summary
- require explicit edit action for WhatsApp templates with pencil icons
- support a default birthday reminder message and migration
- use birthday template when sending WhatsApp reminders

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `npx eslint src/components/SettingsModal.tsx src/components/settings/SettingsModalContent.tsx src/components/settings/WhatsAppTab.tsx src/hooks/useOrganization.ts src/integrations/supabase/types.ts src/pages/Reminders.tsx src/services/organizationSettingsService.ts src/types/organization.ts src/utils/messageTemplates.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a5e4785d88330ba5d9ffe7b8453cc