### PR TITLE
fix: show preselected date in date picker

### DIFF
--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -36,6 +36,7 @@ export function DatePicker({
   React.useEffect(() => {
     if (selected) {
       setInputValue(format(selected, 'dd/MM/yyyy', { locale: ptBR }));
+      setViewMonth(selected);
     } else {
       setInputValue("");
     }


### PR DESCRIPTION
## Summary
- ensure the date picker opens on the previously selected month

## Testing
- `npm run lint` *(fails: Unexpected any, require import)*

------
https://chatgpt.com/codex/tasks/task_e_689d0b5924dc83308b9cb371d467c85b