### PR TITLE
Link reminder cards to related pages

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -79,7 +79,7 @@ export default function Appointments() {
     end: Number(organizationSettings?.working_hours_end ?? 18),
   };
   const [scrollTargetHour, setScrollTargetHour] = useState(8);
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const scheduleRef = useRef<HTMLDivElement>(null);
   const firstHourRef = useRef<HTMLDivElement>(null);
   const timeColumnWidth = '3rem';
@@ -102,6 +102,20 @@ export default function Appointments() {
       }
     }
   }, [searchParams, workingHours.start, workingHours.end]);
+
+  useEffect(() => {
+    const appointmentId = searchParams.get('appointmentId');
+    if (appointmentId && appointments.length > 0) {
+      const appt = appointments.find(a => a.id === appointmentId);
+      if (appt) {
+        setSelectedAppointment(appt);
+        setIsModalOpen(true);
+        const params = new URLSearchParams(searchParams);
+        params.delete('appointmentId');
+        setSearchParams(params);
+      }
+    }
+  }, [searchParams, appointments, setSearchParams]);
 
   const getAppointmentsForTimeSlot = (date: Date, hour: number) => {
     const slotStart = addHours(startOfDay(date), hour);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useOrganization } from '@/hooks/useOrganization';
 import { useSupabasePatients } from '@/hooks/useSupabasePatients';
 import { AuthGuard } from '@/components/AuthGuard';
@@ -16,6 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { AlertCircle, Users, Calendar, Settings, UserPlus, Clock } from 'lucide-react';
 import { isAfter, format, parseISO, startOfDay } from 'date-fns';
 import { useAuth as useSupabaseAuth } from '@/hooks/useAuth';
+import { useSearchParams } from 'react-router-dom';
 
 const Index = () => {
   const { user, loading: authLoading, signOut } = useSupabaseAuth();
@@ -39,6 +40,7 @@ const Index = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [paymentFilter, setPaymentFilter] = useState<'all' | 'particular' | 'convenio'>('all');
   const patientsListRef = useRef<HTMLDivElement>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Filtering logic
   const today = startOfDay(new Date());
@@ -173,6 +175,20 @@ const Index = () => {
     if (!user?.id) return;
     await bulkAddPatients(patientsData, user.id);
   };
+
+  useEffect(() => {
+    const patientId = searchParams.get('patientId');
+    if (patientId && patients.length > 0) {
+      const patient = patients.find(p => p.id === patientId);
+      if (patient) {
+        setEditingPatient(patient);
+        setShowPatientForm(true);
+        const params = new URLSearchParams(searchParams);
+        params.delete('patientId');
+        setSearchParams(params);
+      }
+    }
+  }, [searchParams, patients, setSearchParams]);
 
   if (authLoading || orgLoading) {
     console.log('⏳ Index: showing loading state');


### PR DESCRIPTION
## Summary
- make reminder cards open appointment or patient editing based on type
- support appointmentId query param to open appointment editor
- support patientId query param to open patient editor

## Testing
- `npm run lint` *(fails: Unexpected any types, forbidden require import in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689d0c7167848330873235151ddae317