### PR TITLE
fix mobile multi-slot selection

### DIFF
--- a/src/components/schedule/WeekSchedule.tsx
+++ b/src/components/schedule/WeekSchedule.tsx
@@ -211,7 +211,7 @@ export function WeekSchedule(props: WeekScheduleProps) {
             <div key={day.toISOString()} className="relative border-r">
               {/* Background clickable slots with pointer handlers */}
               <div
-                className="relative"
+                className="relative touch-none"
                 onPointerDown={(e) => {
                   const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
                   const offsetY = e.clientY - rect.top;


### PR DESCRIPTION
## Summary
- prevent screen scroll from interrupting multi-slot drag selection on mobile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 14 errors, 16 warnings)

------
https://chatgpt.com/codex/tasks/task_e_689d0f7841688330956ff892db013c88