### PR TITLE
feat: add monthly view for appointments

### DIFF
--- a/src/components/schedule/MonthSchedule.tsx
+++ b/src/components/schedule/MonthSchedule.tsx
@@ -1,0 +1,74 @@
+import { addDays, endOfMonth, endOfWeek, format, isSameDay, isSameMonth, setYear, startOfMonth, startOfWeek } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { Appointment } from '@/types/appointment';
+import { Patient } from '@/types/patient';
+import { Button } from '@/components/ui/button';
+import { Cake, Calendar } from 'lucide-react';
+
+interface MonthScheduleProps {
+  currentMonth: Date;
+  appointments: Appointment[];
+  patients: Patient[];
+  onDayClick: (date: Date) => void;
+}
+
+export function MonthSchedule({ currentMonth, appointments, patients, onDayClick }: MonthScheduleProps) {
+  const monthStart = startOfMonth(currentMonth);
+  const monthEnd = endOfMonth(currentMonth);
+  const startDate = startOfWeek(monthStart, { weekStartsOn: 1 });
+  const endDate = endOfWeek(monthEnd, { weekStartsOn: 1 });
+
+  const days: Date[] = [];
+  for (let day = startDate; day <= endDate; day = addDays(day, 1)) {
+    days.push(day);
+  }
+
+  const weekDayNames = Array.from({ length: 7 }, (_, i) =>
+    format(addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), i), 'EEEEEE', {
+      locale: ptBR,
+    })
+  );
+
+  const year = currentMonth.getFullYear();
+
+  const hasAppointment = (day: Date) =>
+    appointments.some((a) => isSameDay(new Date(a.start_time), day));
+
+  const hasBirthday = (day: Date) =>
+    patients.some((p) => p.birthDate && isSameDay(setYear(p.birthDate, year), day));
+
+  return (
+    <div className="w-full">
+      <div className="grid grid-cols-7 text-center text-xs font-medium">
+        {weekDayNames.map((name) => (
+          <div key={name} className="p-2">
+            {name}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7">
+        {days.map((day) => {
+          const inMonth = isSameMonth(day, monthStart);
+          const appt = hasAppointment(day);
+          const birthday = hasBirthday(day);
+          return (
+            <Button
+              key={day.toISOString()}
+              variant="ghost"
+              className={`h-16 sm:h-24 p-1 sm:p-2 flex flex-col items-start gap-1 rounded-none border ${
+                inMonth ? 'bg-background' : 'bg-muted text-muted-foreground'
+              }`}
+              onClick={() => onDayClick(day)}
+            >
+              <span className="text-xs sm:text-sm">{format(day, 'd')}</span>
+              <div className="flex gap-1">
+                {appt && <Calendar className="h-3 w-3 text-blue-500" />}
+                {birthday && <Cake className="h-3 w-3 text-pink-500" />}
+              </div>
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add MonthSchedule component to show monthly calendar with appointment and birthday markers
- integrate MonthSchedule in appointments page with toggle between week and month views

## Testing
- `npm run lint` *(fails: Unexpected any and require import errors)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d10ed94b48330bd45ae56380bf983