### PR TITLE
Remove redundant mobile user avatar

### DIFF
--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -183,14 +183,6 @@ export const AppNavigation: React.FC<AppNavigationProps> = ({
               )}
             </div>
 
-            {/* Mobile user avatar in top bar */}
-            {isMobile && (
-              <UserAvatar
-                userProfile={userProfile}
-                onSettingsClick={onSettingsClick}
-                onSignOut={onSignOut}
-              />
-            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Remove duplicate avatar in mobile top bar, leaving profile access in sidebar only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and no-require-imports errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d17fb50a48330b74607f5482635d0