### PR TITLE
fix: enforce organization-based RLS for appointments

### DIFF
--- a/supabase/migrations/20250908090000-fix-appointments-rls.sql
+++ b/supabase/migrations/20250908090000-fix-appointments-rls.sql
@@ -1,0 +1,36 @@
+-- Strengthen RLS policies for appointments to ensure organization isolation
+DROP POLICY IF EXISTS "appointments_select_user_org" ON public.appointments;
+DROP POLICY IF EXISTS "appointments_insert_user_org" ON public.appointments;
+DROP POLICY IF EXISTS "appointments_update_user_org" ON public.appointments;
+DROP POLICY IF EXISTS "appointments_delete_user_org" ON public.appointments;
+
+CREATE POLICY "appointments_select_user_org"
+ON public.appointments
+FOR SELECT
+USING (
+  public.user_belongs_to_organization(organization_id)
+);
+
+CREATE POLICY "appointments_insert_user_org"
+ON public.appointments
+FOR INSERT
+WITH CHECK (
+  public.user_belongs_to_organization(organization_id)
+);
+
+CREATE POLICY "appointments_update_user_org"
+ON public.appointments
+FOR UPDATE
+USING (
+  public.user_belongs_to_organization(organization_id)
+)
+WITH CHECK (
+  public.user_belongs_to_organization(organization_id)
+);
+
+CREATE POLICY "appointments_delete_user_org"
+ON public.appointments
+FOR DELETE
+USING (
+  public.user_belongs_to_organization(organization_id)
+);


### PR DESCRIPTION
## Summary
- strengthen appointments RLS policies to verify user membership via `user_belongs_to_organization`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint found errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4737a814833097095f36f935340f