### PR TITLE
fix: restrict organization settings insert permissions

### DIFF
--- a/supabase/migrations/20250909130000-restrict-org-settings-insert.sql
+++ b/supabase/migrations/20250909130000-restrict-org-settings-insert.sql
@@ -1,0 +1,9 @@
+-- Drop permissive policy allowing inserts from any user
+DROP POLICY IF EXISTS org_settings_insert_any ON public.organization_settings;
+
+-- Ensure only organization members can insert settings for their organization
+DROP POLICY IF EXISTS organization_settings_insert_user_org ON public.organization_settings;
+CREATE POLICY organization_settings_insert_user_org
+  ON public.organization_settings
+  FOR INSERT
+  WITH CHECK (organization_id = get_user_organization_id());


### PR DESCRIPTION
## Summary
- drop `org_settings_insert_any` policy from `organization_settings`
- require organization membership when inserting organization settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, prefer-const, react hooks dependencies, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ab28a888330b50fcf90ee64f820