### PR TITLE
Restrict organization settings inserts to authenticated users

### DIFF
--- a/supabase/migrations/20250909130000-restrict-org-settings-insert.sql
+++ b/supabase/migrations/20250909130000-restrict-org-settings-insert.sql
@@ -6,4 +6,5 @@ DROP POLICY IF EXISTS organization_settings_insert_user_org ON public.organizati
 CREATE POLICY organization_settings_insert_user_org
   ON public.organization_settings
   FOR INSERT
+  TO authenticated
   WITH CHECK (organization_id = get_user_organization_id());


### PR DESCRIPTION
## Summary
- secure organization settings by dropping permissive policy and limiting inserts to authenticated users' organization

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d4be03b1c833085a00a5f237ac30a