### PR TITLE
feat: restrict deletion of organization settings

### DIFF
--- a/supabase/migrations/20250909140000-restrict-org-settings-delete.sql
+++ b/supabase/migrations/20250909140000-restrict-org-settings-delete.sql
@@ -1,0 +1,9 @@
+-- Restrict deletion of organization settings to organization members
+DROP POLICY IF EXISTS org_settings_delete_any ON public.organization_settings;
+
+DROP POLICY IF EXISTS organization_settings_delete_user_org ON public.organization_settings;
+CREATE POLICY organization_settings_delete_user_org
+  ON public.organization_settings
+  FOR DELETE
+  TO authenticated
+  USING (organization_id = get_user_organization_id());


### PR DESCRIPTION
## Summary
- limit organization settings deletions to members of the same organization by adding RLS policy

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: found 14 errors, 15 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689d4ee46b2083308e5ab69481fcbaab