### PR TITLE
fix: add title to reminders top bar

### DIFF
--- a/src/pages/Reminders.tsx
+++ b/src/pages/Reminders.tsx
@@ -194,6 +194,7 @@ const Reminders: React.FC = () => {
         userProfile={userProfile}
         onSettingsClick={() => {}}
         onSignOut={signOut}
+        topBarContent="Lembretes"
       >
         <div className="p-4 space-y-4">
           <ReminderFilterBar


### PR DESCRIPTION
## Summary
- show "Lembretes" in the reminders page top bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npx eslint src/pages/Reminders.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d4f465f948330a9408ec8e8266d70