### PR TITLE
fix: handle patient birth date timezone

### DIFF
--- a/src/utils/patientConverters.ts
+++ b/src/utils/patientConverters.ts
@@ -26,7 +26,9 @@ export const convertToDbPatient = (
     name: patient.name,
     phone: patient.phone,
     secondary_phone: patient.secondaryPhone || null,
-    birth_date: patient.birthDate ? patient.birthDate.toISOString() : null,
+    birth_date: patient.birthDate
+      ? patient.birthDate.toISOString().split('T')[0]
+      : null,
     last_visit: patient.lastVisit.toISOString(),
     next_contact_reason: patient.nextContactReason,
     next_contact_date: patient.nextContactDate.toISOString(),
@@ -51,7 +53,9 @@ export const convertToAppPatient = (
     name: dbPatient.name,
     phone: dbPatient.phone,
     secondaryPhone: dbPatient.secondary_phone || undefined,
-    birthDate: dbPatient.birth_date ? new Date(dbPatient.birth_date) : undefined,
+    birthDate: dbPatient.birth_date
+      ? new Date(`${dbPatient.birth_date}T00:00:00`)
+      : undefined,
     lastVisit: new Date(dbPatient.last_visit),
     nextContactReason: dbPatient.next_contact_reason,
     nextContactDate: new Date(dbPatient.next_contact_date),


### PR DESCRIPTION
## Summary
- preserve patient birthday across navigation by storing only date portion in DB and parsing with local timezone

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 14 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e8847065c8330af4dc9bd9758c821