### PR TITLE
Add WhatsApp appointment location variable

### DIFF
--- a/src/components/AppointmentModal.tsx
+++ b/src/components/AppointmentModal.tsx
@@ -281,7 +281,7 @@ export function AppointmentModal({
     if (!appointment?.patient?.phone) return;
     const template =
       organizationSettings?.whatsapp_appointment_message ||
-      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}.';
+      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta} no {local_de_atendimento}.';
     const message = formatMessage(template, {
       patient: appointment.patient,
       appointment,

--- a/src/components/PatientAppointments.tsx
+++ b/src/components/PatientAppointments.tsx
@@ -32,7 +32,7 @@ export const PatientAppointments: React.FC<PatientAppointmentsProps> = ({
     e.stopPropagation();
     const defaultMessage =
       organizationSettings?.whatsapp_appointment_message ||
-      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}.';
+      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta} no {local_de_atendimento}.';
     const message = formatMessage(defaultMessage, { patient, appointment });
     const phone = patient.phone;
     const url = `https://wa.me/55${phone.replace(/\D/g, '')}?text=${encodeURIComponent(

--- a/src/components/settings/WhatsAppTab.tsx
+++ b/src/components/settings/WhatsAppTab.tsx
@@ -132,7 +132,7 @@ export const WhatsAppTab: React.FC<WhatsAppTabProps> = ({
             disabled={!editAppointment}
           />
           <p className="text-xs text-dental-secondary mt-2">
-            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{primeiro_nome_do_paciente}'}, {'{data_consulta}'}, {'{hora_consulta}'}
+            Variáveis disponíveis: {'{nome_do_paciente}'}, {'{primeiro_nome_do_paciente}'}, {'{data_consulta}'}, {'{hora_consulta}'}, {'{local_de_atendimento}'}
           </p>
           {editAppointment && (
             <div className="flex gap-2 mt-2">

--- a/src/services/organizationSettingsService.ts
+++ b/src/services/organizationSettingsService.ts
@@ -43,7 +43,7 @@ export class OrganizationSettingsService {
     const defaultMessage =
       'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!';
     const defaultAppointmentMessage =
-      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}. Até breve!';
+      'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta} no {local_de_atendimento}. Até breve!';
     const defaultBirthdayMessage =
       'Olá {nome_do_paciente}! Feliz aniversário! Desejamos um dia cheio de sorrisos!';
 
@@ -98,7 +98,7 @@ export class OrganizationSettingsService {
           whatsapp_default_message:
             'Olá {nome_do_paciente}! Este é um lembrete da sua consulta marcada para {data_proximo_contato}. Aguardamos você!',
           whatsapp_appointment_message:
-            'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta}. Até breve!',
+            'Olá {nome_do_paciente}! Lembrete da sua consulta em {data_consulta} às {hora_consulta} no {local_de_atendimento}. Até breve!',
           whatsapp_birthday_message:
             'Olá {nome_do_paciente}! Feliz aniversário! Desejamos um dia cheio de sorrisos!',
           working_hours_start: 8,

--- a/src/utils/messageTemplates.ts
+++ b/src/utils/messageTemplates.ts
@@ -51,6 +51,13 @@ export function formatMessage(template: string, { patient, appointment }: Messag
         '{hora_consulta}',
         format(new Date(appointment.start_time), 'HH:mm', { locale: ptBR })
       );
+
+    if (appointment.location) {
+      const locationInfo = appointment.location.address
+        ? `${appointment.location.name} - ${appointment.location.address}`
+        : appointment.location.name;
+      message = message.replace('{local_de_atendimento}', locationInfo);
+    }
   }
 
   return message;


### PR DESCRIPTION
## Summary
- allow templates to include appointment location with `{local_de_atendimento}`
- expose new variable in WhatsApp settings and default messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 29 problems (14 errors, 15 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a0f25ad34883309cb1fe79815a9feb