### PR TITLE
feat: add calendar exceptions service

### DIFF
--- a/src/domain/calendarExceptions.spec.ts
+++ b/src/domain/calendarExceptions.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { composeEffectiveAvailability, CalendarException, WorkingHours } from './calendarExceptions';
+
+describe('composeEffectiveAvailability', () => {
+  const base: WorkingHours = { start: 8, end: 17 };
+
+  it('returns null when blackout applies', () => {
+    const exceptions: CalendarException[] = [
+      {
+        id: '1',
+        type: 'BLACKOUT',
+        dateStart: '2024-08-10T00:00:00.000Z',
+        dateEnd: '2024-08-11T00:00:00.000Z',
+        reason: 'Holiday',
+        locationId: null,
+        recurrence: null,
+        createdAt: '2024-07-01T00:00:00.000Z',
+      },
+    ];
+    const result = composeEffectiveAvailability(new Date('2024-08-10T12:00:00.000Z'), base, exceptions);
+    expect(result).toBeNull();
+  });
+
+  it('expands hours for extra opening on closed day', () => {
+    const baseClosed: WorkingHours = { start: 0, end: 0 };
+    const exceptions: CalendarException[] = [
+      {
+        id: '2',
+        type: 'EXTRA_OPEN',
+        dateStart: '2024-08-10T09:00:00.000Z',
+        dateEnd: '2024-08-10T12:00:00.000Z',
+        locationId: null,
+        recurrence: null,
+        createdAt: '2024-07-01T00:00:00.000Z',
+      },
+    ];
+    const result = composeEffectiveAvailability(new Date('2024-08-10T00:00:00.000Z'), baseClosed, exceptions);
+    expect(result).toEqual({ start: 9, end: 12 });
+  });
+
+  it('adjusts working hours for day adjustment', () => {
+    const exceptions: CalendarException[] = [
+      {
+        id: '3',
+        type: 'DAY_ADJUST',
+        dateStart: '2024-08-12T10:00:00.000Z',
+        dateEnd: '2024-08-12T16:00:00.000Z',
+        locationId: null,
+        recurrence: null,
+        createdAt: '2024-07-01T00:00:00.000Z',
+      },
+    ];
+    const result = composeEffectiveAvailability(new Date('2024-08-12T00:00:00.000Z'), base, exceptions);
+    expect(result).toEqual({ start: 10, end: 16 });
+  });
+});
+

--- a/src/domain/calendarExceptions.ts
+++ b/src/domain/calendarExceptions.ts
@@ -1,0 +1,116 @@
+export type ExceptionType = 'BLACKOUT' | 'EXTRA_OPEN' | 'DAY_ADJUST';
+
+export interface CalendarException {
+  id: string;
+  type: ExceptionType;
+  dateStart: string;
+  dateEnd: string;
+  reason?: string;
+  locationId?: string | null;
+  recurrence?: string | null;
+  createdAt: string;
+  createdBy?: string;
+}
+
+const STORAGE_KEY = 'sorriso.exceptions.v1';
+
+function readLocal(): CalendarException[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as CalendarException[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLocal(list: CalendarException[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+}
+
+export async function listExceptions(): Promise<CalendarException[]> {
+  try {
+    const res = await fetch('/api/exceptions');
+    if (!res.ok) throw new Error('API error');
+    return (await res.json()) as CalendarException[];
+  } catch {
+    return readLocal();
+  }
+}
+
+export async function addException(exc: CalendarException): Promise<CalendarException> {
+  try {
+    const res = await fetch('/api/exceptions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(exc),
+    });
+    if (!res.ok) throw new Error('API error');
+    return (await res.json()) as CalendarException;
+  } catch {
+    const list = readLocal();
+    list.push(exc);
+    writeLocal(list);
+    return exc;
+  }
+}
+
+export async function removeException(id: string): Promise<void> {
+  try {
+    const res = await fetch(`/api/exceptions/${id}`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('API error');
+  } catch {
+    const list = readLocal().filter((e) => e.id !== id);
+    writeLocal(list);
+  }
+}
+
+export interface WorkingHours {
+  start: number;
+  end: number;
+}
+
+function toHour(dateStr: string): number {
+  const d = new Date(dateStr);
+  return d.getUTCHours() + d.getUTCMinutes() / 60;
+}
+
+export function composeEffectiveAvailability(
+  date: Date,
+  base: WorkingHours,
+  exceptions: CalendarException[],
+): WorkingHours | null {
+  const dayStart = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayEnd = new Date(dayStart);
+  dayEnd.setUTCDate(dayEnd.getUTCDate() + 1);
+
+  const applicable = exceptions.filter((ex) => {
+    const exStart = new Date(ex.dateStart);
+    const exEnd = new Date(ex.dateEnd);
+    return exEnd > dayStart && exStart < dayEnd;
+  });
+
+  if (applicable.some((ex) => ex.type === 'BLACKOUT')) {
+    return null;
+  }
+
+  let result: WorkingHours = { ...base };
+
+  for (const ex of applicable) {
+    if (ex.type === 'DAY_ADJUST') {
+      result = { start: toHour(ex.dateStart), end: toHour(ex.dateEnd) };
+    } else if (ex.type === 'EXTRA_OPEN') {
+      const startHour = toHour(ex.dateStart);
+      const endHour = toHour(ex.dateEnd);
+      if (result.start >= result.end) {
+        result = { start: startHour, end: endHour };
+      } else {
+        result = { start: Math.min(result.start, startHour), end: Math.max(result.end, endHour) };
+      }
+    }
+  }
+
+  return result;
+}
+


### PR DESCRIPTION
## Summary
- add calendar exception types and persistence helpers
- implement effective availability computation
- test blackout, extra opening and day adjustment scenarios

## Testing
- `npm run lint` *(fails: Unexpected any / require issues)*
- `npx vitest run src/domain/calendarExceptions.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a0fc72be2c83309390192df80a3435