### PR TITLE
Show calendar exceptions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -100,3 +100,15 @@
     @apply bg-dental-background text-foreground;
   }
 }
+
+@layer utilities {
+  .bg-hatched {
+    background-image: repeating-linear-gradient(
+      45deg,
+      hsl(var(--foreground) / 0.1) 0,
+      hsl(var(--foreground) / 0.1) 2px,
+      transparent 2px,
+      transparent 4px
+    );
+  }
+}

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -327,6 +327,11 @@ export default function Appointments() {
   };
   const daysToDisplay = isMobile ? weekDays.slice(selectedDayIndex, selectedDayIndex + mobileDays) : weekDays;
 
+  const dayAvailability = useMemo(
+    () => daysToDisplay.map((day) => composeEffectiveAvailability(day, baseHours, exceptions)),
+    [daysToDisplay, baseHours.start, baseHours.end, exceptions]
+  );
+
   const hasAfterHoursAppointments = useMemo(() =>
     appointments.some((a) =>
       daysToDisplay.some((day) => {
@@ -487,6 +492,7 @@ export default function Appointments() {
                     isMobile={isMobile}
                     daysToDisplay={daysToDisplay}
                     workingHours={workingHours}
+                    dayAvailability={dayAvailability}
                     appointments={appointments}
                     onTimeSlotClick={handleTimeSlotClick}
                     onTimeRangeSelect={handleTimeRangeSelect}
@@ -503,6 +509,7 @@ export default function Appointments() {
                   currentMonth={currentMonth}
                   appointments={appointments}
                   patients={patients}
+                  exceptions={exceptions}
                   onDayLongPress={handleDayLongPress}
                   onDayClick={(date) => {
                     setCurrentDate(date);


### PR DESCRIPTION
## Summary
- highlight calendar exceptions in week and month views
- add hatched background utility for marking unavailable time

## Testing
- `npm run lint` *(fails: Unexpected any and require import issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a112df7e608330b811c4fc34ab7e0a