### PR TITLE
feat: manage calendar exceptions

### DIFF
--- a/src/components/schedule/WeekSchedule.tsx
+++ b/src/components/schedule/WeekSchedule.tsx
@@ -226,13 +226,7 @@ export function WeekSchedule(props: WeekScheduleProps) {
                   const offsetY = e.clientY - rect.top;
                   const offsetIndex = Math.max(0, Math.min(totalRenderedSlots - 1, Math.floor(offsetY / SLOT_HEIGHT_PX)));
                   const index = offsetIndex + renderStartSlot;
-                  const hour = index / SLOTS_PER_HOUR;
-                  const allowed =
-                    !weekend &&
-                    !!effective &&
-                    hour >= effective.start &&
-                    hour < effective.end;
-                  if (!allowed) return;
+                  // Allow selecting slots even outside working hours; hatched cells act as warnings only.
                   setDrag({
                     dayISO: day.toISOString(),
                     startIndex: index,
@@ -310,7 +304,7 @@ export function WeekSchedule(props: WeekScheduleProps) {
                   const hasException = dayClosed || !isWorking;
                   const cellClass =
                     weekend || hasException
-                      ? 'bg-muted/10 hover:bg-muted/20 opacity-60 bg-hatched cursor-not-allowed'
+                      ? 'bg-muted/10 hover:bg-muted/20 opacity-60 bg-hatched cursor-pointer'
                       : 'hover:bg-muted/30 cursor-pointer';
                   const isHourBoundary = slotIndex % SLOTS_PER_HOUR === 0;
                   return (

--- a/src/domain/calendarExceptions.ts
+++ b/src/domain/calendarExceptions.ts
@@ -56,6 +56,26 @@ export async function addException(exc: CalendarException): Promise<CalendarExce
   }
 }
 
+export async function updateException(exc: CalendarException): Promise<CalendarException> {
+  try {
+    const res = await fetch(`/api/exceptions/${exc.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(exc),
+    });
+    if (!res.ok) throw new Error('API error');
+    return (await res.json()) as CalendarException;
+  } catch {
+    const list = readLocal();
+    const idx = list.findIndex((e) => e.id === exc.id);
+    if (idx !== -1) {
+      list[idx] = exc;
+      writeLocal(list);
+    }
+    return exc;
+  }
+}
+
 export async function removeException(id: string): Promise<void> {
   try {
     const res = await fetch(`/api/exceptions/${id}`, { method: 'DELETE' });


### PR DESCRIPTION
## Summary
- allow creating appointments during non-working hours
- add calendar exception manager to view, edit and delete entries

## Testing
- `npx -y vitest run`
- `npm run lint` *(fails: Unexpected any in existing services)*

------
https://chatgpt.com/codex/tasks/task_e_68a116395908833092717f36fd42f61d