### PR TITLE
Fix patient location field default

### DIFF
--- a/src/components/patient-form/PatientFormFields.tsx
+++ b/src/components/patient-form/PatientFormFields.tsx
@@ -96,8 +96,7 @@ export const PatientFormFields: React.FC<PatientFormFieldsProps> = ({
       <div>
         <Label htmlFor="locationId">Local / Clínica *</Label>
         <Select
-          value={formData.locationId}
-          defaultValue={formData.locationId}
+          value={formData.locationId || undefined}
           onValueChange={(value) => onChange('locationId', value)}
         >
           <SelectTrigger>


### PR DESCRIPTION
## Summary
- fix patient location select to display saved location when editing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any & forbidden import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ffaa09f08330b7f03226038df203