### PR TITLE
Persist team professionals to Supabase

### DIFF
--- a/src/hooks/useProfessionals.ts
+++ b/src/hooks/useProfessionals.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import { Professional } from '@/types/professional';
+import { ProfessionalService } from '@/services/professionalService';
+
+export const useProfessionals = (organizationId?: string) => {
+  const [professionals, setProfessionals] = useState<Professional[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!organizationId) {
+        setProfessionals([]);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const data = await ProfessionalService.loadProfessionals(organizationId);
+        setProfessionals(data);
+      } catch (error) {
+        console.error('❌ Error loading professionals:', error);
+        setProfessionals([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [organizationId]);
+
+  const addProfessional = async (professional: Omit<Professional, 'id'>) => {
+    if (!organizationId) return;
+    try {
+      const newProfessional = await ProfessionalService.addProfessional(professional, organizationId);
+      setProfessionals(prev => [...prev, newProfessional]);
+    } catch (error) {
+      console.error('❌ Error adding professional:', error);
+    }
+  };
+
+  return { professionals, loading, addProfessional };
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -343,6 +343,53 @@ export type Database = {
           },
         ]
       }
+      professionals: {
+        Row: {
+          id: string
+          organization_id: string
+          first_name: string
+          last_name: string
+          user_email: string | null
+          role: string
+          specialties: string[] | null
+          location_ids: string[] | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          organization_id: string
+          first_name: string
+          last_name: string
+          user_email?: string | null
+          role: string
+          specialties?: string[] | null
+          location_ids?: string[] | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          organization_id?: string
+          first_name?: string
+          last_name?: string
+          user_email?: string | null
+          role?: string
+          specialties?: string[] | null
+          location_ids?: string[] | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "professionals_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       security_audit_log: {
         Row: {
           created_at: string | null

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -11,6 +11,7 @@ import { useAuth as useSupabaseAuth } from '@/hooks/useAuth';
 import { useOrganization } from '@/hooks/useOrganization';
 import { useLocations } from '@/hooks/useLocations';
 import { useProfessionalRoles } from '@/hooks/useProfessionalRoles';
+import { useProfessionals } from '@/hooks/useProfessionals';
 import { Professional } from '@/types/professional';
 
 const Team: React.FC = () => {
@@ -18,8 +19,7 @@ const Team: React.FC = () => {
   const { userProfile, loading: orgLoading } = useOrganization(user);
   const { locations: availableLocations } = useLocations(userProfile?.organization_id);
   const { roles: roleOptions, specialtiesByRole } = useProfessionalRoles(userProfile?.organization_id);
-
-  const [professionals, setProfessionals] = useState<Professional[]>([]);
+  const { professionals, addProfessional } = useProfessionals(userProfile?.organization_id);
   const [showForm, setShowForm] = useState(false);
   const [formData, setFormData] = useState<Omit<Professional, 'id'>>({
     firstName: '',
@@ -48,13 +48,9 @@ const Team: React.FC = () => {
     }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const newProfessional: Professional = {
-      id: Date.now().toString(),
-      ...formData,
-    };
-    setProfessionals(prev => [...prev, newProfessional]);
+    await addProfessional(formData);
     setFormData({ firstName: '', lastName: '', user: '', role: '', specialties: [], locations: [] });
     setShowForm(false);
   };

--- a/src/services/professionalService.ts
+++ b/src/services/professionalService.ts
@@ -1,0 +1,52 @@
+import { supabase } from '@/integrations/supabase/client';
+import { Professional } from '@/types/professional';
+import {
+  convertToDbProfessional,
+  convertToAppProfessional,
+  assertDatabaseProfessional
+} from '@/utils/professionalConverters';
+
+export class ProfessionalService {
+  static async loadProfessionals(organizationId: string): Promise<Professional[]> {
+    if (!organizationId) {
+      return [];
+    }
+
+    const { data, error } = await supabase
+      .from('professionals')
+      .select('*')
+      .eq('organization_id', organizationId)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      console.error('❌ Error loading professionals:', error);
+      throw error;
+    }
+
+    return (data || []).map(p => convertToAppProfessional(assertDatabaseProfessional(p)));
+  }
+
+  static async addProfessional(
+    professionalData: Omit<Professional, 'id'>,
+    organizationId: string
+  ): Promise<Professional> {
+    if (!organizationId) {
+      throw new Error('Organization ID is required');
+    }
+
+    const dbProfessional = convertToDbProfessional(professionalData, organizationId);
+
+    const { data, error } = await supabase
+      .from('professionals')
+      .insert(dbProfessional as any)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('❌ Error adding professional:', error);
+      throw error;
+    }
+
+    return convertToAppProfessional(assertDatabaseProfessional(data));
+  }
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -29,3 +29,16 @@ export interface DatabaseContactRecord {
   successful: boolean;
   created_at: string;
 }
+
+export interface DatabaseProfessional {
+  id: string;
+  organization_id: string;
+  first_name: string;
+  last_name: string;
+  user_email: string | null;
+  role: string;
+  specialties: string[] | null;
+  location_ids: string[] | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/utils/professionalConverters.ts
+++ b/src/utils/professionalConverters.ts
@@ -1,0 +1,42 @@
+import { Professional } from '@/types/professional';
+import { DatabaseProfessional } from '@/types/supabase';
+
+export const convertToDbProfessional = (
+  professional: Omit<Professional, 'id'>,
+  organizationId: string
+): Omit<DatabaseProfessional, 'id' | 'created_at' | 'updated_at'> => ({
+  organization_id: organizationId,
+  first_name: professional.firstName,
+  last_name: professional.lastName,
+  user_email: professional.user || null,
+  role: professional.role,
+  specialties: professional.specialties,
+  location_ids: professional.locations
+});
+
+export const convertToAppProfessional = (
+  dbProfessional: DatabaseProfessional
+): Professional => ({
+  id: dbProfessional.id,
+  firstName: dbProfessional.first_name,
+  lastName: dbProfessional.last_name,
+  user: dbProfessional.user_email || undefined,
+  role: dbProfessional.role,
+  specialties: dbProfessional.specialties || [],
+  locations: dbProfessional.location_ids || []
+});
+
+export const assertDatabaseProfessional = (data: unknown): DatabaseProfessional => {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Invalid professional data: not an object');
+  }
+
+  const required = ['id', 'first_name', 'last_name', 'role', 'organization_id'];
+  for (const field of required) {
+    if (!data[field]) {
+      throw new Error(`Invalid professional data: missing ${field}`);
+    }
+  }
+
+  return data as DatabaseProfessional;
+};

--- a/supabase/migrations/20250911120000_create-professionals-table.sql
+++ b/supabase/migrations/20250911120000_create-professionals-table.sql
@@ -1,0 +1,79 @@
+-- Create table for professionals within organizations
+CREATE TABLE public.professionals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id),
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL,
+  user_email TEXT,
+  role TEXT NOT NULL,
+  specialties TEXT[] DEFAULT '{}'::text[],
+  location_ids UUID[] DEFAULT '{}'::uuid[],
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Enable row level security
+ALTER TABLE public.professionals ENABLE ROW LEVEL SECURITY;
+
+-- Allow members of an organization to view its professionals
+CREATE POLICY "professionals_select"
+ON public.professionals
+FOR SELECT
+USING (
+  organization_id IS NOT NULL AND
+  public.user_belongs_to_organization(organization_id)
+);
+
+-- Allow admins to insert professionals
+CREATE POLICY "professionals_insert_admin"
+ON public.professionals
+FOR INSERT
+WITH CHECK (
+  organization_id IS NOT NULL AND
+  public.user_belongs_to_organization(organization_id) AND
+  EXISTS (
+    SELECT 1 FROM public.user_profiles admin_profile
+    WHERE admin_profile.user_id = auth.uid()
+      AND admin_profile.organization_id = professionals.organization_id
+      AND admin_profile.role = 'admin'
+      AND admin_profile.status = 'approved'
+  )
+);
+
+-- Allow admins to update professionals
+CREATE POLICY "professionals_update_admin"
+ON public.professionals
+FOR UPDATE
+USING (
+  organization_id IS NOT NULL AND
+  public.user_belongs_to_organization(organization_id) AND
+  EXISTS (
+    SELECT 1 FROM public.user_profiles admin_profile
+    WHERE admin_profile.user_id = auth.uid()
+      AND admin_profile.organization_id = professionals.organization_id
+      AND admin_profile.role = 'admin'
+      AND admin_profile.status = 'approved'
+  )
+);
+
+-- Allow admins to delete professionals
+CREATE POLICY "professionals_delete_admin"
+ON public.professionals
+FOR DELETE
+USING (
+  organization_id IS NOT NULL AND
+  public.user_belongs_to_organization(organization_id) AND
+  EXISTS (
+    SELECT 1 FROM public.user_profiles admin_profile
+    WHERE admin_profile.user_id = auth.uid()
+      AND admin_profile.organization_id = professionals.organization_id
+      AND admin_profile.role = 'admin'
+      AND admin_profile.status = 'approved'
+  )
+);
+
+-- Keep updated_at current on updates
+CREATE TRIGGER update_professionals_updated_at
+BEFORE UPDATE ON public.professionals
+FOR EACH ROW
+EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- create `professionals` table with RLS policies and trigger
- add service and hook to load and save professionals in Supabase
- update team page to use Supabase-backed professionals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-control-regex, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b378d0d7d08330bc0de0082fd43701