### PR TITLE
Restrict professional user linking to admins

### DIFF
--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -11,6 +11,7 @@ export interface UserProfile {
   user_id: string;
   organization_id: string;
   name: string;
+  email?: string;
   role: 'admin' | 'user';
   status?: 'pending' | 'approved' | 'rejected';
   created_at: string;


### PR DESCRIPTION
## Summary
- allow admins to select existing organization users when assigning a professional
- expose user emails in organization users service
- add email field to UserProfile type

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / control character etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b37f86300083309b32d2787b36b96a