### PR TITLE
feat: improve cargo search and specialty loading

### DIFF
--- a/src/components/CargoSelect.tsx
+++ b/src/components/CargoSelect.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { CargoOption, getCargos } from '@/services/especialidades';
+
+interface Props {
+  value: CargoOption | null;
+  onChange: (v: CargoOption | null) => void;
+}
+
+export const CargoSelect: React.FC<Props> = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [options, setOptions] = useState<CargoOption[]>([]);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    const handler = setTimeout(async () => {
+      const data = await getCargos(search);
+      setOptions(data);
+    }, 250);
+    return () => clearTimeout(handler);
+  }, [search]);
+
+  const handleSelect = (opt: CargoOption) => {
+    onChange(opt);
+    setOpen(false);
+  };
+
+  const trigger = (
+    <Button
+      type="button"
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      className="w-full justify-between"
+    >
+      {value ? value.nome : 'Selecionar cargo'}
+    </Button>
+  );
+
+  const content = (
+    <Command>
+      <CommandInput
+        value={search}
+        onValueChange={setSearch}
+        placeholder="Buscar cargo..."
+      />
+      <CommandList className="max-h-64 overflow-y-auto">
+        <CommandEmpty>Nenhum cargo encontrado</CommandEmpty>
+        <CommandGroup>
+          {options.map(opt => (
+            <CommandItem
+              key={opt.id}
+              value={opt.nome}
+              onSelect={() => handleSelect(opt)}
+            >
+              {opt.nome}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+
+  return (
+    isMobile ? (
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>{trigger}</SheetTrigger>
+        <SheetContent side="bottom" className="p-0">
+          {content}
+        </SheetContent>
+      </Sheet>
+    ) : (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent className="p-0 w-80">
+          {content}
+        </PopoverContent>
+      </Popover>
+    )
+  );
+};

--- a/src/components/EspecialidadeMultiSelect.tsx
+++ b/src/components/EspecialidadeMultiSelect.tsx
@@ -125,12 +125,7 @@ export const EspecialidadeMultiSelect: React.FC<Props> = ({
           Selecione o cargo para ver especialidades (opcional)
         </p>
       )}
-      {cargoId && options.length === 0 && (
-        <p className="text-sm text-muted-foreground">
-          Não se aplica para este cargo
-        </p>
-      )}
-      {cargoId && (
+        {cargoId && (
         isMobile ? (
           <Sheet open={open} onOpenChange={setOpen}>
             <SheetTrigger asChild>{trigger}</SheetTrigger>


### PR DESCRIPTION
## Summary
- add searchable cargo combobox backed by cargos table
- remove extra texts and mark specialty as optional
- fetch specialties based on selected cargo

## Testing
- `npm run lint` *(fails: 35 problems (18 errors, 17 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b39b08ed5083309c03e743386195fa