### PR TITLE
Encrypt patient data and use secure view

### DIFF
--- a/src/hooks/useAppointments.ts
+++ b/src/hooks/useAppointments.ts
@@ -22,7 +22,7 @@ export const useAppointments = () => {
         .from('appointments')
         .select(`
           *,
-          patient:patients(name, phone),
+          patient:patients_secure(name, phone),
           location:locations(name, address)
         `)
         .eq('organization_id', userProfile.organization_id)

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -14,7 +14,7 @@ export class PatientService {
 
     try {
       const { data, error } = await supabase
-        .from('patients')
+        .from('patients_secure')
         .select('*')
         .eq('organization_id', organizationId)
         .order('next_contact_date', { ascending: true });

--- a/supabase/migrations/20250914120000_encrypt_patients_trigger.sql
+++ b/supabase/migrations/20250914120000_encrypt_patients_trigger.sql
@@ -1,0 +1,51 @@
+-- Ensure patient phone and birth date are encrypted on write
+CREATE OR REPLACE FUNCTION public.encrypt_patient_fields()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' OR NEW.phone IS DISTINCT FROM OLD.phone THEN
+    IF NEW.phone IS NOT NULL THEN
+      NEW.phone := pgp_sym_encrypt(convert_from(NEW.phone, 'UTF8'), current_setting('app.encryption_key', true));
+    END IF;
+  END IF;
+
+  IF TG_OP = 'INSERT' OR NEW.birth_date IS DISTINCT FROM OLD.birth_date THEN
+    IF NEW.birth_date IS NOT NULL THEN
+      NEW.birth_date := pgp_sym_encrypt(convert_from(NEW.birth_date, 'UTF8'), current_setting('app.encryption_key', true));
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS encrypt_patients ON public.patients;
+CREATE TRIGGER encrypt_patients
+BEFORE INSERT OR UPDATE ON public.patients
+FOR EACH ROW EXECUTE FUNCTION public.encrypt_patient_fields();
+
+-- Expose decrypted values through a helper view for authorized users
+CREATE OR REPLACE VIEW public.patients_secure AS
+SELECT
+  p.id,
+  p.name,
+  pgp_sym_decrypt(p.phone, current_setting('app.encryption_key', true))::text AS phone,
+  p.secondary_phone,
+  pgp_sym_decrypt(p.birth_date, current_setting('app.encryption_key', true))::date AS birth_date,
+  p.last_visit,
+  p.next_contact_reason,
+  p.next_contact_date,
+  p.status,
+  p.inactive_reason,
+  p.payment_type,
+  p.location_id,
+  p.organization_id,
+  p.user_id,
+  p.created_at,
+  p.updated_at,
+  p.updated_by
+FROM public.patients AS p;
+
+ALTER VIEW public.patients_secure OWNER TO postgres;
+


### PR DESCRIPTION
## Summary
- Encrypt patient phone and birth date via trigger and expose decrypted view
- Load patients from `patients_secure` view and join appointments against it

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a794254c8330a9408ac0daf07c38